### PR TITLE
Fix text color not applied to new text items

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -269,9 +269,16 @@ class Canvas(QGraphicsView):
 
     def _add_text_item(self, text: str, pos: QPointF) -> QGraphicsItem:
         from PySide6.QtWidgets import QGraphicsTextItem
-        it = QGraphicsTextItem(text)
+        it = QGraphicsTextItem()
         it.setFont(self._font)
         it.setDefaultTextColor(self._text_color)
+        it.setPlainText(text)
+        # apply color to existing text explicitly
+        cursor = QTextCursor(it.document())
+        cursor.select(QTextCursor.Document)
+        fmt = QTextCharFormat()
+        fmt.setForeground(self._text_color)
+        cursor.mergeCharFormat(fmt)
         it.setPos(pos)
         it.setTextInteractionFlags(Qt.TextEditorInteraction)
         it.setFlag(QGraphicsItem.ItemIsMovable, True)


### PR DESCRIPTION
## Summary
- ensure selected color is applied to text content when adding new text items

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a0c48d8a54832cbf30180efa341d6e