### PR TITLE
Refactor editor tool implementations into modular architecture

### DIFF
--- a/editor/tools/__init__.py
+++ b/editor/tools/__init__.py
@@ -1,0 +1,19 @@
+"""Tool implementations used by the editor canvas."""
+
+from .selection_tool import SelectionTool
+from .pencil_tool import PencilTool
+from .shape_tools import RectangleTool, EllipseTool
+from .blur_tool import BlurTool
+from .eraser_tool import EraserTool
+from .line_arrow_tool import LineTool, ArrowTool
+
+__all__ = [
+    "SelectionTool",
+    "PencilTool",
+    "RectangleTool",
+    "EllipseTool",
+    "BlurTool",
+    "EraserTool",
+    "LineTool",
+    "ArrowTool",
+]

--- a/editor/tools/base_tool.py
+++ b/editor/tools/base_tool.py
@@ -1,0 +1,20 @@
+from PySide6.QtCore import QPointF
+
+
+class BaseTool:
+    """Base class for canvas tools."""
+
+    def __init__(self, canvas):
+        self.canvas = canvas
+
+    def press(self, pos: QPointF):
+        """Handle mouse press at scene position."""
+        pass
+
+    def move(self, pos: QPointF):
+        """Handle mouse move while pressing."""
+        pass
+
+    def release(self, pos: QPointF):
+        """Handle mouse release."""
+        pass

--- a/editor/tools/blur_tool.py
+++ b/editor/tools/blur_tool.py
@@ -1,0 +1,56 @@
+from PySide6.QtCore import QPointF, QRectF, Qt
+from PySide6.QtGui import QPen, QColor
+from PySide6.QtWidgets import QGraphicsItem, QGraphicsPixmapItem
+from PIL import ImageFilter
+
+from logic import pil_to_qpixmap, qimage_to_pil
+from .base_tool import BaseTool
+
+
+class BlurTool(BaseTool):
+    """Tool for blurring rectangular regions."""
+
+    def __init__(self, canvas, preview_color):
+        super().__init__(canvas)
+        self._start = None
+        self._tmp = None
+        self.preview_color = preview_color
+
+    def press(self, pos: QPointF):
+        self._start = pos
+        self._tmp = None
+
+    def move(self, pos: QPointF):
+        if self._tmp is None:
+            pen = QPen(Qt.DashLine)
+            pen.setColor(QColor(self.preview_color))
+            self._tmp = self.canvas.scene.addRect(QRectF(self._start, pos).normalized(), pen)
+        else:
+            self._tmp.setRect(QRectF(self._start, pos).normalized())
+
+    def release(self, pos: QPointF):
+        if self._tmp is not None:
+            rect = self._tmp.rect()
+            self.canvas.scene.removeItem(self._tmp)
+            self._tmp = None
+            if rect.width() > 1 and rect.height() > 1:
+                item = self._create_blur_item(rect)
+                if item:
+                    self.canvas._undo.append(item)
+
+    def _create_blur_item(self, rect: QRectF):
+        r = rect.toRect()
+        if r.isNull():
+            return None
+        base = self.canvas.pixmap_item.pixmap().copy(r)
+        qimg = base.toImage()
+        pil_img = qimage_to_pil(qimg)
+        pil_blur = pil_img.filter(ImageFilter.GaussianBlur(12))
+        pix = pil_to_qpixmap(pil_blur)
+        item = QGraphicsPixmapItem(pix)
+        item.setPos(rect.left(), rect.top())
+        item.setZValue(1)
+        item.setFlag(QGraphicsItem.ItemIsSelectable, True)
+        item.setFlag(QGraphicsItem.ItemIsMovable, True)
+        self.canvas.scene.addItem(item)
+        return item

--- a/editor/tools/eraser_tool.py
+++ b/editor/tools/eraser_tool.py
@@ -1,0 +1,27 @@
+from PySide6.QtCore import QPointF
+
+from .base_tool import BaseTool
+
+
+class EraserTool(BaseTool):
+    """Removes top items at the cursor position."""
+
+    def press(self, pos: QPointF):
+        self._erase(pos)
+
+    def move(self, pos: QPointF):
+        self._erase(pos)
+
+    def release(self, pos: QPointF):  # noqa: D401
+        pass
+
+    def _erase(self, pos: QPointF):
+        for item in self.canvas.scene.items(pos):
+            if item is self.canvas.pixmap_item:
+                continue
+            self.canvas.scene.removeItem(item)
+            try:
+                self.canvas._undo.remove(item)
+            except ValueError:
+                pass
+            break

--- a/editor/tools/line_arrow_tool.py
+++ b/editor/tools/line_arrow_tool.py
@@ -1,0 +1,84 @@
+from PySide6.QtCore import QPointF, QLineF
+from PySide6.QtWidgets import QGraphicsItem, QGraphicsItemGroup
+
+from .base_tool import BaseTool
+
+
+class LineTool(BaseTool):
+    """Draws straight lines."""
+
+    def __init__(self, canvas):
+        super().__init__(canvas)
+        self._start = None
+        self._tmp = None
+
+    def press(self, pos: QPointF):
+        self._start = pos
+        self._tmp = None
+
+    def move(self, pos: QPointF):
+        if self._tmp is None:
+            self._tmp = self.canvas.scene.addLine(QLineF(self._start, pos), self.canvas._pen)
+            self._tmp.setFlag(QGraphicsItem.ItemIsMovable, True)
+            self._tmp.setFlag(QGraphicsItem.ItemIsSelectable, True)
+            self.canvas._undo.append(self._tmp)
+        else:
+            self._tmp.setLine(QLineF(self._start, pos))
+
+    def release(self, pos: QPointF):  # noqa: D401
+        self._tmp = None
+
+
+class ArrowTool(BaseTool):
+    """Draws arrows."""
+
+    def __init__(self, canvas):
+        super().__init__(canvas)
+        self._start = None
+        self._tmp = None
+
+    def press(self, pos: QPointF):
+        self._start = pos
+        self._tmp = None
+
+    def move(self, pos: QPointF):
+        if self._tmp is None:
+            self._tmp = self._create_arrow_group(self._start, pos)
+            self._tmp.setFlag(QGraphicsItem.ItemIsSelectable, True)
+            self.canvas._undo.append(self._tmp)
+        else:
+            self.canvas.scene.removeItem(self._tmp)
+            self.canvas._undo.pop()
+            self._tmp = self._create_arrow_group(self._start, pos)
+            self._tmp.setFlag(QGraphicsItem.ItemIsSelectable, True)
+            self.canvas._undo.append(self._tmp)
+
+    def release(self, pos: QPointF):  # noqa: D401
+        self._tmp = None
+
+    def _create_arrow_group(self, start: QPointF, end: QPointF):
+        group = QGraphicsItemGroup()
+        line = self.canvas.scene.addLine(QLineF(start, end), self.canvas._pen)
+        group.addToGroup(line)
+
+        v = end - start
+        length = (v.x() ** 2 + v.y() ** 2) ** 0.5
+        if length >= 1:
+            ux, uy = v.x() / length, v.y() / length
+            head = 12
+            left = QPointF(
+                end.x() - ux * head - uy * head * 0.5,
+                end.y() - uy * head + ux * head * 0.5,
+            )
+            right = QPointF(
+                end.x() - ux * head + uy * head * 0.5,
+                end.y() - uy * head - ux * head * 0.5,
+            )
+            left_line = self.canvas.scene.addLine(QLineF(end, left), self.canvas._pen)
+            right_line = self.canvas.scene.addLine(QLineF(end, right), self.canvas._pen)
+            group.addToGroup(left_line)
+            group.addToGroup(right_line)
+
+        group.setFlag(QGraphicsItem.ItemIsMovable, True)
+        self.canvas.scene.addItem(group)
+        return group

--- a/editor/tools/pencil_tool.py
+++ b/editor/tools/pencil_tool.py
@@ -1,0 +1,26 @@
+from PySide6.QtCore import QPointF, QLineF
+from PySide6.QtWidgets import QGraphicsItem
+
+from .base_tool import BaseTool
+
+
+class PencilTool(BaseTool):
+    """Freehand drawing tool."""
+
+    def __init__(self, canvas):
+        super().__init__(canvas)
+        self._last_point = None
+
+    def press(self, pos: QPointF):
+        self._last_point = pos
+
+    def move(self, pos: QPointF):
+        if self._last_point is not None:
+            line = self.canvas.scene.addLine(QLineF(self._last_point, pos), self.canvas._pen)
+            line.setFlag(QGraphicsItem.ItemIsSelectable, True)
+            line.setFlag(QGraphicsItem.ItemIsMovable, True)
+            self.canvas._undo.append(line)
+            self._last_point = pos
+
+    def release(self, pos: QPointF):  # noqa: D401 - docs inherited
+        self._last_point = None

--- a/editor/tools/selection_tool.py
+++ b/editor/tools/selection_tool.py
@@ -1,0 +1,6 @@
+from .base_tool import BaseTool
+
+
+class SelectionTool(BaseTool):
+    """Tool that relies on built-in selection of the scene."""
+    pass

--- a/editor/tools/shape_tools.py
+++ b/editor/tools/shape_tools.py
@@ -1,0 +1,44 @@
+from PySide6.QtCore import QPointF, QRectF
+from PySide6.QtWidgets import QGraphicsItem
+
+from .base_tool import BaseTool
+
+
+class _BaseShapeTool(BaseTool):
+    def __init__(self, canvas):
+        super().__init__(canvas)
+        self._start = None
+        self._tmp = None
+
+    def press(self, pos: QPointF):
+        self._start = pos
+        self._tmp = None
+
+    def release(self, pos: QPointF):  # noqa: D401
+        self._tmp = None
+
+
+class RectangleTool(_BaseShapeTool):
+    """Draws rectangles."""
+
+    def move(self, pos: QPointF):
+        if self._tmp is None:
+            self._tmp = self.canvas.scene.addRect(QRectF(self._start, pos).normalized(), self.canvas._pen)
+            self._tmp.setFlag(QGraphicsItem.ItemIsSelectable, True)
+            self._tmp.setFlag(QGraphicsItem.ItemIsMovable, True)
+            self.canvas._undo.append(self._tmp)
+        else:
+            self._tmp.setRect(QRectF(self._start, pos).normalized())
+
+
+class EllipseTool(_BaseShapeTool):
+    """Draws ellipses."""
+
+    def move(self, pos: QPointF):
+        if self._tmp is None:
+            self._tmp = self.canvas.scene.addEllipse(QRectF(self._start, pos).normalized(), self.canvas._pen)
+            self._tmp.setFlag(QGraphicsItem.ItemIsSelectable, True)
+            self._tmp.setFlag(QGraphicsItem.ItemIsMovable, True)
+            self.canvas._undo.append(self._tmp)
+        else:
+            self._tmp.setRect(QRectF(self._start, pos).normalized())


### PR DESCRIPTION
## Summary
- Split drawing tools into dedicated modules under `editor/tools`
- Simplify `Canvas` in `main_editor.py` to delegate events to these modules
- Added package initializer for easy tool imports

## Testing
- `python -m py_compile editor/main_editor.py editor/tools/*.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1c7f2cd08832c97c147eedaa2edc8