### PR TITLE
Show recent screenshots instead of collage

### DIFF
--- a/collage.py
+++ b/collage.py
@@ -1,41 +1,59 @@
-from typing import List
+from typing import List, Tuple
 from pathlib import Path
-from PIL import Image
-from PySide6.QtWidgets import (QDialog, QVBoxLayout, QGridLayout, QCheckBox, QPushButton,
-                               QLabel, QHBoxLayout, QSpinBox)
-from logic import HISTORY_DIR, smart_grid
+
+from PySide6.QtCore import Qt, QSize
+from PySide6.QtGui import QIcon, QPixmap
+from PySide6.QtWidgets import (
+    QDialog,
+    QGridLayout,
+    QHBoxLayout,
+    QPushButton,
+    QToolButton,
+    QVBoxLayout,
+)
+
+from logic import HISTORY_DIR
+
 
 class CollageDialog(QDialog):
+    """Dialog to pick recent screenshots instead of creating a collage."""
+
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setWindowTitle("Коллаж")
-        self.setMinimumWidth(600)
+        self.setWindowTitle("История скриншотов")
         layout = QVBoxLayout(self)
+
         self.grid = QGridLayout()
         layout.addLayout(self.grid)
-        self.checks: List[QCheckBox] = []
-        paths = sorted(HISTORY_DIR.glob("shot_*.png"), key=lambda p: p.stat().st_mtime, reverse=True)[:20]
-        for i, p in enumerate(paths):
-            cb = QCheckBox(p.name)
-            cb.setChecked(i < 4)
-            self.checks.append(cb)
-            btn = QPushButton("Просмотр")
-            btn.clicked.connect(lambda _, pp=p: Image.open(pp).show())
-            self.grid.addWidget(cb, i, 0)
-            self.grid.addWidget(QLabel(str(p)), i, 1)
-            self.grid.addWidget(btn, i, 2)
 
-        h = QHBoxLayout()
-        layout.addLayout(h)
-        self.width_spin = QSpinBox()
-        self.width_spin.setRange(400, 8000)
-        self.width_spin.setValue(1600)
-        h.addWidget(QLabel("Ширина:"))
-        h.addWidget(self.width_spin)
+        self._buttons: List[Tuple[QToolButton, Path]] = []
+
+        paths = sorted(
+            HISTORY_DIR.glob("shot_*.png"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )[:10]
+
+        for i, p in enumerate(paths):
+            btn = QToolButton()
+            btn.setCheckable(True)
+            pix = QPixmap(str(p))
+            if not pix.isNull():
+                btn.setIcon(
+                    QIcon(
+                        pix.scaled(
+                            160, 90, Qt.KeepAspectRatio, Qt.SmoothTransformation
+                        )
+                    )
+                )
+                btn.setIconSize(QSize(160, 90))
+            btn.setToolTip(p.name)
+            self._buttons.append((btn, p))
+            self.grid.addWidget(btn, i // 5, i % 5)
 
         row = QHBoxLayout()
         row.addStretch(1)
-        ok = QPushButton("Создать")
+        ok = QPushButton("Добавить")
         ok.clicked.connect(self.accept)
         cancel = QPushButton("Отмена")
         cancel.clicked.connect(self.reject)
@@ -43,33 +61,10 @@ class CollageDialog(QDialog):
         row.addWidget(cancel)
         layout.addLayout(row)
 
-    @property
-    def target_width(self) -> int:
-        return self.width_spin.value()
-
     def selected_images(self) -> List[Path]:
-        out = []
-        for i, cb in enumerate(self.checks):
-            if cb.isChecked():
-                out.append(Path(self.grid.itemAtPosition(i, 1).widget().text()))
+        out: List[Path] = []
+        for btn, path in self._buttons:
+            if btn.isChecked():
+                out.append(path)
         return out
 
-def compose_collage(paths: List[Path], target_width: int) -> Image.Image:
-    cols, rows = smart_grid(len(paths))
-    aspect = 9/16
-    target_height = int(target_width * aspect)
-    cell_w = target_width // cols
-    cell_h = target_height // rows
-    canvas = Image.new("RGBA", (cell_w * cols, cell_h * rows), (30,30,30,255))
-    i = 0
-    for r in range(rows):
-        for c in range(cols):
-            if i >= len(paths):
-                break
-            im = Image.open(paths[i]).convert("RGBA")
-            im.thumbnail((cell_w, cell_h), Image.Resampling.LANCZOS)
-            x = c * cell_w + (cell_w - im.width)//2
-            y = r * cell_h + (cell_h - im.height)//2
-            canvas.paste(im, (x, y), im)
-            i += 1
-    return canvas

--- a/editor/ui/toolbar_factory.py
+++ b/editor/ui/toolbar_factory.py
@@ -327,7 +327,7 @@ def create_actions_toolbar(window, canvas):
     actions['live_copy'], _ = add_action("Текст", window.copy_live_text, sc="Ctrl+Shift+C", icon_text="📄",
                                          show_text=False)
     actions['new'], _ = add_action("Новый снимок", window.add_screenshot, sc="Ctrl+N", icon_text="📸", show_text=False)
-    actions['collage'], _ = add_action("Коллаж", window.open_collage, sc="Ctrl+K", icon_text="🧩", show_text=False)
+    actions['collage'], _ = add_action("История", window.open_collage, sc="Ctrl+K", icon_text="🖼", show_text=False)
     add_action("Копировать", window.copy_to_clipboard, sc="Ctrl+C", icon_text="📋", show_text=False)
     add_action("Сохранить", window.save_image, sc="Ctrl+S", icon_text="💾", show_text=False)
     add_action("Отмена", lambda: canvas.undo(), sc="Ctrl+Z", icon_text="↶", show_text=False)


### PR DESCRIPTION
## Summary
- Replace collage dialog with thumbnail history viewer that shows up to 10 recent screenshots
- Insert selected history shots into editor directly using shared helper
- Rename collage action to history and update status hints

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2097189a0832c9383f5ecedaa745a