### PR TITLE
Remove Live Text copy button

### DIFF
--- a/editor/editor_logic.py
+++ b/editor/editor_logic.py
@@ -33,10 +33,5 @@ class EditorLogic:
     def toggle_live_text(self):
         return self.live_manager.toggle()
 
-    def copy_live_text(self, parent):
-        if self.live_manager.active and self.live_manager.copy_selection_to_clipboard():
-            return True
-        return False
-
     def collage_available(self):
         return any(HISTORY_DIR.glob("*.png")) or any(HISTORY_DIR.glob("*.jpg")) or any(HISTORY_DIR.glob("*.jpeg"))

--- a/editor/editor_window.py
+++ b/editor/editor_window.py
@@ -45,7 +45,6 @@ class EditorWindow(QMainWindow):
         self._tool_buttons = create_tools_toolbar(self, self.canvas)
         self.color_btn, actions = create_actions_toolbar(self, self.canvas)
         self.act_live = actions['live']
-        self.act_live_copy = actions['live_copy']
         self.act_new = actions['new']
         self.act_collage = actions['collage']
         if hasattr(self, 'act_collage'):
@@ -53,7 +52,7 @@ class EditorWindow(QMainWindow):
 
         QTimer.singleShot(0, lambda q=qimg: size_to_image(self, q))
 
-        self.statusBar().showMessage("Готово | Ctrl+N: новый скриншот | Ctrl+K: история | Ctrl+L: Live | Ctrl+Shift+C: текст | Del: удалить | Ctrl +/-: масштаб", 5000)
+        self.statusBar().showMessage("Готово | Ctrl+N: новый скриншот | Ctrl+K: история | Ctrl+L: Live | Del: удалить | Ctrl +/-: масштаб", 5000)
 
     # ---- actions ----
     def choose_color(self):
@@ -80,13 +79,9 @@ class EditorWindow(QMainWindow):
     def toggle_live_text(self):
         ok = self.logic.toggle_live_text()
         if ok:
-            self.statusBar().showMessage("🔍 Live Text — включено. Выдели мышью область и жми Ctrl+Shift+C", 3500)
+            self.statusBar().showMessage("🔍 Live Text — включено", 3500)
         else:
             self.statusBar().showMessage("🔍 Live Text — выключено", 2000)
-
-    def copy_live_text(self):
-        if self.logic.copy_live_text(self):
-            self.statusBar().showMessage("📋 Текст скопирован (Live)", 2500)
 
     def _update_collage_enabled(self):
         try:

--- a/editor/live_ocr.py
+++ b/editor/live_ocr.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# editor/live_ocr.py — «Live Text» поверх скриншота: выделение слов прямоугольником и копирование
+# editor/live_ocr.py — «Live Text» поверх скриншота: выделение слов прямоугольником
 from __future__ import annotations
 
 from typing import List, Dict, Optional
@@ -223,16 +223,6 @@ class LiveTextManager:
         self.layer = None
         self.pixmap_item = None
         self.active = False
-
-    def copy_selection_to_clipboard(self) -> bool:
-        if not self.active or not self.layer:
-            return False
-        txt = self.layer.selected_text()
-        if not txt:
-            return False
-        from PySide6.QtWidgets import QApplication
-        QApplication.clipboard().setText(txt)
-        return True
 
     # ---------- helpers ----------
     @staticmethod

--- a/editor/ui/toolbar_factory.py
+++ b/editor/ui/toolbar_factory.py
@@ -324,8 +324,6 @@ def create_actions_toolbar(window, canvas):
 
     actions: Dict[str, QAction] = {}
     actions['live'], _ = add_action("Live", window.toggle_live_text, sc="Ctrl+L", icon_text="🔍", show_text=False)
-    actions['live_copy'], _ = add_action("Текст", window.copy_live_text, sc="Ctrl+Shift+C", icon_text="📄",
-                                         show_text=False)
     actions['new'], _ = add_action("Новый снимок", window.add_screenshot, sc="Ctrl+N", icon_text="📸", show_text=False)
     actions['collage'], _ = add_action("История", window.open_collage, sc="Ctrl+K", icon_text="🖼", show_text=False)
     add_action("Копировать", window.copy_to_clipboard, sc="Ctrl+C", icon_text="📋", show_text=False)


### PR DESCRIPTION
## Summary
- remove obsolete "Text" action from the toolbar
- drop unused copy_live_text and related logic

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a20cafdde8832c941cf31f86b431ef