### PR TITLE
feat: rounded rectangle selections

### DIFF
--- a/editor/live_ocr.py
+++ b/editor/live_ocr.py
@@ -6,9 +6,9 @@ from typing import List, Dict, Optional
 from dataclasses import dataclass
 
 from PySide6.QtCore import Qt, QRectF, QPointF, QObject, QEvent
-from PySide6.QtGui import QPen, QColor
+from PySide6.QtGui import QPen, QColor, QPainterPath
 from PySide6.QtWidgets import (
-    QGraphicsRectItem, QGraphicsItemGroup, QGraphicsItem, QGraphicsView
+    QGraphicsItemGroup, QGraphicsItem, QGraphicsView, QGraphicsPathItem
 )
 
 import pytesseract
@@ -29,9 +29,12 @@ class WordBox:
     word: int
 
 
-class _WordItem(QGraphicsRectItem):
+class _WordItem(QGraphicsPathItem):
     def __init__(self, box: WordBox):
-        super().__init__(QRectF(box.left, box.top, box.width, box.height))
+        rect = QRectF(box.left, box.top, box.width, box.height)
+        path = QPainterPath()
+        path.addRoundedRect(rect, 4, 4)
+        super().__init__(path)
         self.box = box
         self.setPen(QPen(QColor(255, 200, 0, 220), 1))
         self.setBrush(QColor(255, 230, 120, 50))
@@ -141,10 +144,14 @@ class _ViewportFilter(QObject):
         if scene is None:
             return
         if self.rubber is None:
-            self.rubber = scene.addRect(QRectF(), QPen(QColor(70, 130, 240), 2))
+            path = QPainterPath()
+            path.addRoundedRect(QRectF(), 8, 8)
+            self.rubber = scene.addPath(path, QPen(QColor(70, 130, 240), 2))
             self.rubber.setZValue(1000)
         rect = QRectF(self.start_scene, self.end_scene).normalized()
-        self.rubber.setRect(rect)
+        path = QPainterPath()
+        path.addRoundedRect(rect, 8, 8)
+        self.rubber.setPath(path)
 
         layer = self.manager.layer
         if not layer:

--- a/editor/text_tools.py
+++ b/editor/text_tools.py
@@ -3,7 +3,7 @@ from typing import Optional
 from PySide6.QtCore import QPointF, Qt, QRectF
 from PySide6.QtGui import QFont, QColor, QTextCursor, QTextCharFormat, QPen, QPainter
 from PySide6.QtWidgets import (QGraphicsItem, QGraphicsTextItem,
-                               QGraphicsRectItem, QGraphicsItemGroup)
+                               QGraphicsItemGroup)
 
 
 class EditableTextItem(QGraphicsTextItem):
@@ -155,7 +155,7 @@ class EditableTextItem(QGraphicsTextItem):
             pen = QPen(QColor(70, 130, 240), 1, Qt.DashLine)
             painter.setPen(pen)
             painter.setBrush(Qt.NoBrush)
-            painter.drawRect(rect)
+            painter.drawRoundedRect(rect, 8, 8)
 
             # Рисуем маленькие квадратики по углам для изменения размера
             handle_size = 6
@@ -176,7 +176,7 @@ class EditableTextItem(QGraphicsTextItem):
                     handle_size,
                     handle_size
                 )
-                painter.drawRect(handle_rect)
+                painter.drawRoundedRect(handle_rect, 2, 2)
 
             painter.restore()
 

--- a/editor/tools/shape_tools.py
+++ b/editor/tools/shape_tools.py
@@ -1,4 +1,5 @@
 from PySide6.QtCore import QPointF, QRectF
+from PySide6.QtGui import QPainterPath
 from PySide6.QtWidgets import QGraphicsItem
 
 from .base_tool import BaseTool
@@ -22,13 +23,16 @@ class RectangleTool(_BaseShapeTool):
     """Draws rectangles."""
 
     def move(self, pos: QPointF):
+        rect = QRectF(self._start, pos).normalized()
+        path = QPainterPath()
+        path.addRoundedRect(rect, 12, 12)
         if self._tmp is None:
-            self._tmp = self.canvas.scene.addRect(QRectF(self._start, pos).normalized(), self.canvas._pen)
+            self._tmp = self.canvas.scene.addPath(path, self.canvas._pen)
             self._tmp.setFlag(QGraphicsItem.ItemIsSelectable, True)
             self._tmp.setFlag(QGraphicsItem.ItemIsMovable, True)
             self.canvas._undo.append(self._tmp)
         else:
-            self._tmp.setRect(QRectF(self._start, pos).normalized())
+            self._tmp.setPath(path)
 
 
 class EllipseTool(_BaseShapeTool):

--- a/gui.py
+++ b/gui.py
@@ -125,14 +125,22 @@ class SelectionOverlayBase(QWidget):
             loc = QRect(gr.x() - self.geometry().x(), gr.y() - self.geometry().y(), gr.width(), gr.height())
 
             if self.shape == "rect":
+                path = QPainterPath()
+                path.addRoundedRect(QRectF(loc), 12, 12)
+                p.save()
+                p.setClipPath(path)
                 p.drawPixmap(loc, self._bg_original_scaled, loc)
+                p.restore()
+                p.setBrush(Qt.NoBrush)
                 # Более стильная рамка
                 p.setPen(QPen(QColor(70, 130, 240), 3, Qt.SolidLine))
-                p.drawRect(loc)
+                p.drawPath(path)
                 # Внутренняя светлая рамка
                 p.setPen(QPen(QColor(255, 255, 255, 180), 1, Qt.SolidLine))
-                inner_rect = QRect(loc.x() + 1, loc.y() + 1, loc.width() - 2, loc.height() - 2)
-                p.drawRect(inner_rect)
+                inner_rect = QRectF(loc.x() + 1, loc.y() + 1, loc.width() - 2, loc.height() - 2)
+                inner_path = QPainterPath()
+                inner_path.addRoundedRect(inner_rect, 11, 11)
+                p.drawPath(inner_path)
             else:
                 path = QPainterPath()
                 path.addEllipse(QRectF(loc))


### PR DESCRIPTION
## Summary
- render screenshot selection with rounded rectangle borders
- draw rounded rectangles within the editor
- use rounded corners for text item handles and Live Text selection

## Testing
- `python -m py_compile gui.py editor/tools/shape_tools.py editor/text_tools.py editor/live_ocr.py`


------
https://chatgpt.com/codex/tasks/task_e_68a211d14d20832caa3d0e573d110da5