### PR TITLE
Add QUndoStack for full undo/redo and tidy live layer shutdown

### DIFF
--- a/editor.py
+++ b/editor.py
@@ -1,12 +1,22 @@
 # -*- coding: utf-8 -*-
-from typing import Optional, List
+from typing import Optional, List, Dict
 from pathlib import Path
 import pytesseract
 from PIL import Image, ImageQt
 
 from PySide6.QtCore import Qt, QRectF, QPointF, QLineF, QSize, QTimer
 from PySide6.QtGui import (
-    QPainter, QPen, QColor, QImage, QKeySequence, QPixmap, QAction, QFont, QCursor
+    QPainter,
+    QPen,
+    QColor,
+    QImage,
+    QKeySequence,
+    QPixmap,
+    QAction,
+    QFont,
+    QCursor,
+    QUndoStack,
+    QUndoCommand,
 )
 from PySide6.QtWidgets import (
     QMainWindow, QGraphicsView, QGraphicsScene, QGraphicsPixmapItem, QGraphicsItem,
@@ -15,6 +25,72 @@ from PySide6.QtWidgets import (
 )
 
 from logic import pil_to_qpixmap, qimage_to_pil, HISTORY_DIR, save_history
+
+
+class AddCommand(QUndoCommand):
+    def __init__(self, scene: QGraphicsScene, item: QGraphicsItem):
+        super().__init__("add")
+        self.scene = scene
+        self.item = item
+        self._done = True
+
+    def undo(self):
+        self.scene.removeItem(self.item)
+        self._done = False
+
+    def redo(self):
+        if not self._done:
+            self.scene.addItem(self.item)
+            self._done = True
+
+
+class DeleteCommand(QUndoCommand):
+    def __init__(self, scene: QGraphicsScene, item: QGraphicsItem):
+        super().__init__("delete")
+        self.scene = scene
+        self.item = item
+
+    def undo(self):
+        self.scene.addItem(self.item)
+
+    def redo(self):
+        self.scene.removeItem(self.item)
+
+
+class MoveCommand(QUndoCommand):
+    def __init__(self, item: QGraphicsItem, old_pos: QPointF, new_pos: QPointF):
+        super().__init__("move")
+        self.item = item
+        self.old = old_pos
+        self.new = new_pos
+        self._done = True
+
+    def undo(self):
+        self.item.setPos(self.old)
+        self._done = False
+
+    def redo(self):
+        if not self._done:
+            self.item.setPos(self.new)
+            self._done = True
+
+
+class ScaleCommand(QUndoCommand):
+    def __init__(self, item: QGraphicsItem, old_scale: float, new_scale: float):
+        super().__init__("scale")
+        self.item = item
+        self.old = old_scale
+        self.new = new_scale
+        self._done = True
+
+    def undo(self):
+        self.item.setScale(self.old)
+        self._done = False
+
+    def redo(self):
+        if not self._done:
+            self.item.setScale(self.new)
+            self._done = True
 
 
 class Canvas(QGraphicsView):
@@ -55,8 +131,9 @@ class Canvas(QGraphicsView):
         self._pen.setJoinStyle(Qt.RoundJoin)
 
         self._font_px = 18
-        self._undo: List[QGraphicsItem] = []
+        self.undo_stack = QUndoStack(self)
         self._last_point: Optional[QPointF] = None
+        self._move_start: Dict[QGraphicsItem, QPointF] = {}
 
     def set_tool(self, tool: str):
         self._tool = tool
@@ -81,40 +158,40 @@ class Canvas(QGraphicsView):
         p.end()
         return ImageQt.ImageQt.toImage(img).copy() if hasattr(ImageQt.ImageQt, "toImage") else ImageQt.ImageQt(img)
 
-    # --- Undo ---
-    def undo(self):
-        if self._undo:
-            item = self._undo.pop()
-            self.scene.removeItem(item)
-
     # Масштабирование выбранных элементов: Ctrl + колесо
     def wheelEvent(self, event):
         if event.modifiers() & Qt.ControlModifier:
             selected = self.scene.selectedItems()
             if selected:
-                factor = 1.1 if event.angleDelta().y() > 0 else 1/1.1
+                factor = 1.1 if event.angleDelta().y() > 0 else 1 / 1.1
                 for it in selected:
-                    it.setScale(it.scale() * factor)
+                    old = it.scale()
+                    new = old * factor
+                    it.setScale(new)
+                    self.undo_stack.push(ScaleCommand(it, old, new))
                 event.accept()
                 return
         super().wheelEvent(event)
 
     # --- Мышь/отрисовка ---
     def mousePressEvent(self, event):
-        if event.button() == Qt.LeftButton and self._tool != "none":
-            self._start = self.mapToScene(event.position().toPoint())
-            if self._tool == "text":
-                from PySide6.QtWidgets import QInputDialog
-                text, ok = QInputDialog.getText(self, "Текст", "Введите текст:")
-                if ok and text:
-                    item = self._add_text_item(text, self._start)
-                    self._undo.append(item)
-                return
-            elif self._tool == "free":
-                self._last_point = self._start
-                self._tmp = None
+        if event.button() == Qt.LeftButton:
+            if self._tool == "none":
+                self._move_start = {it: it.pos() for it in self.scene.selectedItems()}
             else:
-                self._tmp = None
+                self._start = self.mapToScene(event.position().toPoint())
+                if self._tool == "text":
+                    from PySide6.QtWidgets import QInputDialog
+                    text, ok = QInputDialog.getText(self, "Текст", "Введите текст:")
+                    if ok and text:
+                        item = self._add_text_item(text, self._start)
+                        self.undo_stack.push(AddCommand(self.scene, item))
+                    return
+                elif self._tool == "free":
+                    self._last_point = self._start
+                    self._tmp = None
+                else:
+                    self._tmp = None
         super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event):
@@ -124,7 +201,8 @@ class Canvas(QGraphicsView):
                 if self._last_point is not None:
                     line = self.scene.addLine(QLineF(self._last_point, pos), self._pen)
                     line.setFlag(QGraphicsItem.ItemIsSelectable, True)
-                    self._undo.append(line)
+                    line.setFlag(QGraphicsItem.ItemIsMovable, True)
+                    self.undo_stack.push(AddCommand(self.scene, line))
                     self._last_point = pos
             else:
                 if self._tmp:
@@ -133,14 +211,22 @@ class Canvas(QGraphicsView):
         super().mouseMoveEvent(event)
 
     def mouseReleaseEvent(self, event):
-        if event.button() == Qt.LeftButton and self._tool != "none":
-            if self._tool == "free":
-                self._last_point = None
+        if event.button() == Qt.LeftButton:
+            if self._tool == "none":
+                for item, old_pos in self._move_start.items():
+                    new_pos = item.pos()
+                    if old_pos != new_pos:
+                        self.undo_stack.push(MoveCommand(item, old_pos, new_pos))
+                self._move_start.clear()
             else:
-                if self._tmp:
-                    self._tmp.setFlag(QGraphicsItem.ItemIsSelectable, True)
-                    self._undo.append(self._tmp)
-                    self._tmp = None
+                if self._tool == "free":
+                    self._last_point = None
+                else:
+                    if self._tmp:
+                        self._tmp.setFlag(QGraphicsItem.ItemIsSelectable, True)
+                        self._tmp.setFlag(QGraphicsItem.ItemIsMovable, True)
+                        self.undo_stack.push(AddCommand(self.scene, self._tmp))
+                        self._tmp = None
         super().mouseReleaseEvent(event)
 
     def _preview_item(self, tool: str, start: QPointF, end: QPointF, pen: QPen) -> QGraphicsItem:
@@ -161,16 +247,23 @@ class Canvas(QGraphicsView):
     def _add_arrow(self, start: QPointF, end: QPointF, pen: QPen) -> QGraphicsItem:
         line = self.scene.addLine(QLineF(start, end), pen)
         v = end - start
-        length = (v.x()**2 + v.y()**2) ** 0.5
+        length = (v.x() ** 2 + v.y() ** 2) ** 0.5
         if length < 1:
             return line
-        ux, uy = v.x()/length, v.y()/length
+        ux, uy = v.x() / length, v.y() / length
         head = 12
-        left = QPointF(end.x() - ux * head - uy * head * 0.5, end.y() - uy * head + ux * head * 0.5)
-        right = QPointF(end.x() - ux * head + uy * head * 0.5, end.y() - uy * head - ux * head * 0.5)
-        self.scene.addLine(QLineF(end, left), pen)
-        self.scene.addLine(QLineF(end, right), pen)
-        return line
+        left = QPointF(
+            end.x() - ux * head - uy * head * 0.5,
+            end.y() - uy * head + ux * head * 0.5,
+        )
+        right = QPointF(
+            end.x() - ux * head + uy * head * 0.5,
+            end.y() - uy * head - ux * head * 0.5,
+        )
+        l1 = self.scene.addLine(QLineF(end, left), pen)
+        l2 = self.scene.addLine(QLineF(end, right), pen)
+        group = self.scene.createItemGroup([line, l1, l2])
+        return group
 
     def _add_text_item(self, text: str, pos: QPointF) -> QGraphicsItem:
         from PySide6.QtWidgets import QGraphicsTextItem
@@ -266,7 +359,24 @@ class EditorWindow(QMainWindow):
         create_tool("Текст", "text", "📝", "T")
 
         tb.addSeparator()
-        add_action("Отмена", lambda: self.canvas.undo(), sc="Ctrl+Z", icon_text="↶")
+        undo_action = self.canvas.undo_stack.createUndoAction(self, "Отмена")
+        undo_action.setShortcut(QKeySequence("Ctrl+Z"))
+        undo_action.setShortcutContext(Qt.WindowShortcut)
+        self.addAction(undo_action)
+        undo_btn = QToolButton(); undo_btn.setDefaultAction(undo_action)
+        undo_btn.setText("↶ Отмена")
+        undo_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
+        tb.addWidget(undo_btn)
+
+        redo_action = self.canvas.undo_stack.createRedoAction(self, "Повтор")
+        redo_action.setShortcut(QKeySequence("Ctrl+Y"))
+        redo_action.setShortcutContext(Qt.WindowShortcut)
+        self.addAction(redo_action)
+        redo_btn = QToolButton(); redo_btn.setDefaultAction(redo_action)
+        redo_btn.setText("↷ Повтор")
+        redo_btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
+        tb.addWidget(redo_btn)
+
         tb.addSeparator()
         add_action("Копировать", self.copy_to_clipboard, sc="Ctrl+C", icon_text="📋")
         add_action("Сохранить", self.save_image, sc="Ctrl+S", icon_text="💾")
@@ -319,21 +429,26 @@ class EditorWindow(QMainWindow):
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Delete:
-            selected_items = self.canvas.scene.selectedItems()
+            selected_items = [it for it in self.canvas.scene.selectedItems() if it != self.canvas.pixmap_item]
             for item in selected_items:
-                if item != self.canvas.pixmap_item:
-                    self.canvas.scene.removeItem(item)
-                    if item in self.canvas._undo:
-                        self.canvas._undo.remove(item)
+                self.canvas.undo_stack.push(DeleteCommand(self.canvas.scene, item))
             if selected_items:
                 self.statusBar().showMessage("🗑️ Удалены выбранные элементы", 2000)
         elif event.modifiers() & Qt.ControlModifier:
             selected_items = [it for it in self.canvas.scene.selectedItems()]
             if selected_items:
                 if event.key() in (Qt.Key_Plus, Qt.Key_Equal):
-                    for it in selected_items: it.setScale(it.scale() * 1.1)
+                    factor = 1.1
                 elif event.key() == Qt.Key_Minus:
-                    for it in selected_items: it.setScale(it.scale() * 0.9)
+                    factor = 0.9
+                else:
+                    factor = None
+                if factor is not None:
+                    for it in selected_items:
+                        old = it.scale()
+                        new = old * factor
+                        it.setScale(new)
+                        self.canvas.undo_stack.push(ScaleCommand(it, old, new))
         super().keyPressEvent(event)
 
     def add_screenshot(self):
@@ -386,6 +501,7 @@ class EditorWindow(QMainWindow):
         screenshot_item.setFlag(QGraphicsItem.ItemIsFocusable, True)
         screenshot_item.setZValue(10)
         self.canvas.scene.addItem(screenshot_item)
+        self.canvas.undo_stack.push(AddCommand(self.canvas.scene, screenshot_item))
 
         # Центрируем и выбираем слой, отдаём фокус канвасу
         view_center = self.canvas.mapToScene(self.canvas.viewport().rect().center())
@@ -407,3 +523,12 @@ class EditorWindow(QMainWindow):
                 return
             img = compose_collage(paths, dlg.target_width)
             EditorWindow(ImageQt.ImageQt(img), self.cfg).show()
+
+    def closeEvent(self, event):
+        try:
+            if hasattr(self, "live_manager"):
+                self.live_manager.disable()
+                QApplication.instance().removeEventFilter(self.live_manager)
+        except Exception:
+            pass
+        super().closeEvent(event)


### PR DESCRIPTION
## Summary
- replace ad-hoc undo list with QUndoStack commands (add, move, scale, delete)
- expose undo/redo actions with Ctrl+Z / Ctrl+Y and track item moves/scales
- ensure EditorWindow cleanly disables live layer on close

## Testing
- `python -m py_compile editor.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2271785c0832cacb6836a8de87acc