### PR TITLE
feat: integrate undo stack and clean live layer on close

### DIFF
--- a/editor/tools/blur_tool.py
+++ b/editor/tools/blur_tool.py
@@ -5,6 +5,7 @@ from PIL import ImageFilter
 
 from logic import pil_to_qpixmap, qimage_to_pil
 from .base_tool import BaseTool
+from editor.undo_commands import AddCommand
 
 
 class BlurTool(BaseTool):
@@ -36,7 +37,7 @@ class BlurTool(BaseTool):
             if rect.width() > 1 and rect.height() > 1:
                 item = self._create_blur_item(rect)
                 if item:
-                    self.canvas._undo.append(item)
+                    self.canvas.undo_stack.push(AddCommand(self.canvas.scene, item))
 
     def _create_blur_item(self, rect: QRectF):
         r = rect.toRect()

--- a/editor/tools/eraser_tool.py
+++ b/editor/tools/eraser_tool.py
@@ -1,6 +1,7 @@
 from PySide6.QtCore import QPointF
 
 from .base_tool import BaseTool
+from editor.undo_commands import RemoveCommand
 
 
 class EraserTool(BaseTool):
@@ -20,8 +21,5 @@ class EraserTool(BaseTool):
             if item is self.canvas.pixmap_item:
                 continue
             self.canvas.scene.removeItem(item)
-            try:
-                self.canvas._undo.remove(item)
-            except ValueError:
-                pass
+            self.canvas.undo_stack.push(RemoveCommand(self.canvas.scene, item))
             break

--- a/editor/tools/pencil_tool.py
+++ b/editor/tools/pencil_tool.py
@@ -2,6 +2,7 @@ from PySide6.QtCore import QPointF, QLineF
 from PySide6.QtWidgets import QGraphicsItem
 
 from .base_tool import BaseTool
+from editor.undo_commands import AddCommand
 
 
 class PencilTool(BaseTool):
@@ -19,7 +20,7 @@ class PencilTool(BaseTool):
             line = self.canvas.scene.addLine(QLineF(self._last_point, pos), self.canvas._pen)
             line.setFlag(QGraphicsItem.ItemIsSelectable, True)
             line.setFlag(QGraphicsItem.ItemIsMovable, True)
-            self.canvas._undo.append(line)
+            self.canvas.undo_stack.push(AddCommand(self.canvas.scene, line))
             self._last_point = pos
 
     def release(self, pos: QPointF):  # noqa: D401 - docs inherited

--- a/editor/tools/shape_tools.py
+++ b/editor/tools/shape_tools.py
@@ -3,6 +3,7 @@ from PySide6.QtGui import QPainterPath
 from PySide6.QtWidgets import QGraphicsItem
 
 from .base_tool import BaseTool
+from editor.undo_commands import AddCommand
 
 
 class _BaseShapeTool(BaseTool):
@@ -30,7 +31,7 @@ class RectangleTool(_BaseShapeTool):
             self._tmp = self.canvas.scene.addPath(path, self.canvas._pen)
             self._tmp.setFlag(QGraphicsItem.ItemIsSelectable, True)
             self._tmp.setFlag(QGraphicsItem.ItemIsMovable, True)
-            self.canvas._undo.append(self._tmp)
+            self.canvas.undo_stack.push(AddCommand(self.canvas.scene, self._tmp))
         else:
             self._tmp.setPath(path)
 
@@ -43,6 +44,6 @@ class EllipseTool(_BaseShapeTool):
             self._tmp = self.canvas.scene.addEllipse(QRectF(self._start, pos).normalized(), self.canvas._pen)
             self._tmp.setFlag(QGraphicsItem.ItemIsSelectable, True)
             self._tmp.setFlag(QGraphicsItem.ItemIsMovable, True)
-            self.canvas._undo.append(self._tmp)
+            self.canvas.undo_stack.push(AddCommand(self.canvas.scene, self._tmp))
         else:
             self._tmp.setRect(QRectF(self._start, pos).normalized())

--- a/editor/ui/toolbar_factory.py
+++ b/editor/ui/toolbar_factory.py
@@ -328,7 +328,19 @@ def create_actions_toolbar(window, canvas):
     actions['collage'], _ = add_action("История", window.open_collage, sc="Ctrl+K", icon_text="🖼", show_text=False)
     add_action("Копировать", window.copy_to_clipboard, sc="Ctrl+C", icon_text="📋", show_text=False)
     add_action("Сохранить", window.save_image, sc="Ctrl+S", icon_text="💾", show_text=False)
-    add_action("Отмена", lambda: canvas.undo(), sc="Ctrl+Z", icon_text="↶", show_text=False)
+
+    undo_act = canvas.undo_stack.createUndoAction(window, "Отмена")
+    undo_act.setShortcut(QKeySequence("Ctrl+Z"))
+    redo_act = canvas.undo_stack.createRedoAction(window, "Повтор")
+    redo_act.setShortcut(QKeySequence("Ctrl+Y"))
+    window.addAction(undo_act)
+    window.addAction(redo_act)
+    for act, text in ((undo_act, "↶"), (redo_act, "↷")):
+        btn = QToolButton()
+        btn.setDefaultAction(act)
+        btn.setText(text)
+        btn.setToolButtonStyle(QToolButton.TextOnly)
+        tb.addWidget(btn)
 
     # Применяем улучшенные стили
     tb.setStyleSheet(enhanced_actions_toolbar_style())

--- a/editor/undo_commands.py
+++ b/editor/undo_commands.py
@@ -1,0 +1,68 @@
+from PySide6.QtGui import QUndoCommand
+from PySide6.QtWidgets import QGraphicsScene, QGraphicsItem
+
+
+class AddCommand(QUndoCommand):
+    """Command to add an item to the scene."""
+
+    def __init__(self, scene: QGraphicsScene, item: QGraphicsItem):
+        super().__init__("Добавить")
+        self.scene = scene
+        self.item = item
+
+    def undo(self):
+        self.scene.removeItem(self.item)
+
+    def redo(self):
+        if self.item.scene() is None:
+            self.scene.addItem(self.item)
+
+
+class RemoveCommand(QUndoCommand):
+    """Command to remove an item from the scene."""
+
+    def __init__(self, scene: QGraphicsScene, item: QGraphicsItem):
+        super().__init__("Удалить")
+        self.scene = scene
+        self.item = item
+
+    def undo(self):
+        if self.item.scene() is None:
+            self.scene.addItem(self.item)
+
+    def redo(self):
+        self.scene.removeItem(self.item)
+
+
+class MoveCommand(QUndoCommand):
+    """Command to move items between positions."""
+
+    def __init__(self, items_pos):
+        # items_pos: Dict[QGraphicsItem, Tuple[QPointF, QPointF]]
+        super().__init__("Переместить")
+        self.items_pos = items_pos
+
+    def undo(self):
+        for item, (old, new) in self.items_pos.items():
+            item.setPos(old)
+
+    def redo(self):
+        for item, (old, new) in self.items_pos.items():
+            item.setPos(new)
+
+
+class ScaleCommand(QUndoCommand):
+    """Command to scale items."""
+
+    def __init__(self, items_scale):
+        # items_scale: Dict[QGraphicsItem, Tuple[float, float]]
+        super().__init__("Масштабировать")
+        self.items_scale = items_scale
+
+    def undo(self):
+        for item, (old, new) in self.items_scale.items():
+            item.setScale(old)
+
+    def redo(self):
+        for item, (old, new) in self.items_scale.items():
+            item.setScale(new)


### PR DESCRIPTION
## Summary
- replace ad-hoc undo list with QUndoStack and commands for add, remove, move and scale
- hook canvas actions to undo stack for proper Ctrl+Z / Ctrl+Y and movement rollbacks
- disable Live Text and remove its event filter on editor window close

## Testing
- `python -m py_compile editor/undo_commands.py editor/ui/canvas.py editor/tools/pencil_tool.py editor/tools/shape_tools.py editor/tools/line_arrow_tool.py editor/tools/blur_tool.py editor/tools/eraser_tool.py editor/editor_window.py editor/ui/toolbar_factory.py`


------
https://chatgpt.com/codex/tasks/task_e_68a229c24d4c832cad730378f774fc04