### PR TITLE
Fix QToolButton style attribute

### DIFF
--- a/editor/ui/toolbar_factory.py
+++ b/editor/ui/toolbar_factory.py
@@ -339,7 +339,7 @@ def create_actions_toolbar(window, canvas):
         btn = QToolButton()
         btn.setDefaultAction(act)
         btn.setText(text)
-        btn.setToolButtonStyle(QToolButton.TextOnly)
+        btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
         tb.addWidget(btn)
 
     # Применяем улучшенные стили


### PR DESCRIPTION
## Summary
- correct QToolButton style usage to Qt.ToolButtonTextOnly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a22bebcebc832c9669a0b36fc462ce