### PR TITLE
Group pencil strokes into single undo step

### DIFF
--- a/editor/tools/pencil_tool.py
+++ b/editor/tools/pencil_tool.py
@@ -11,12 +11,18 @@ class PencilTool(BaseTool):
     def __init__(self, canvas):
         super().__init__(canvas)
         self._last_point = None
+        self._drawing = False
 
     def press(self, pos: QPointF):
         self._last_point = pos
+        self._drawing = False
 
     def move(self, pos: QPointF):
         if self._last_point is not None:
+            if not self._drawing:
+                # Start a macro so the whole stroke becomes a single undo step
+                self.canvas.undo_stack.beginMacro("Карандаш")
+                self._drawing = True
             line = self.canvas.scene.addLine(QLineF(self._last_point, pos), self.canvas._pen)
             line.setFlag(QGraphicsItem.ItemIsSelectable, True)
             line.setFlag(QGraphicsItem.ItemIsMovable, True)
@@ -25,3 +31,7 @@ class PencilTool(BaseTool):
 
     def release(self, pos: QPointF):  # noqa: D401 - docs inherited
         self._last_point = None
+        if self._drawing:
+            # Finish the macro when the stroke ends
+            self.canvas.undo_stack.endMacro()
+            self._drawing = False


### PR DESCRIPTION
## Summary
- Start and end a QUndoStack macro around pencil drawing to treat an entire stroke as a single undoable action.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a22e0c6278832cbabff337cb42e9eb