### PR TITLE
Use SlipSnap name and icon

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -8,9 +8,9 @@ from typing import Tuple, Optional
 import mss
 from PIL import Image, ImageQt
 
-APP_NAME = "Screenshot"
-CONFIG_PATH = Path.home() / ".screenshot_config.json"
-HISTORY_DIR = Path(tempfile.gettempdir()) / "screenshot_history"
+APP_NAME = "SlipSnap"
+CONFIG_PATH = Path.home() / ".slipsnap_config.json"
+HISTORY_DIR = Path(tempfile.gettempdir()) / "slipsnap_history"
 HISTORY_DIR.mkdir(parents=True, exist_ok=True)
 
 DEFAULT_CONFIG = {

--- a/main.py
+++ b/main.py
@@ -1,10 +1,18 @@
-from PySide6.QtWidgets import QApplication
+from pathlib import Path
 import sys
+
+from PySide6.QtWidgets import QApplication
+from PySide6.QtGui import QIcon
+
 from gui import App
 
 def main():
     app = QApplication(sys.argv)
-    app.setApplicationName("Screenshot")
+    app.setApplicationName("SlipSnap")
+
+    icon_path = Path(__file__).resolve().with_name("SlipSnap.ico")
+    if icon_path.exists():
+        app.setWindowIcon(QIcon(str(icon_path)))
     global _APP_CTX
     _APP_CTX = App()
     sys.exit(app.exec())


### PR DESCRIPTION
## Summary
- Set application name to SlipSnap and load optional SlipSnap.ico icon.
- Rename config and history paths to SlipSnap-specific names.

## Testing
- `python -m py_compile main.py logic.py`

------
https://chatgpt.com/codex/tasks/task_e_68a2598e16d8832ca82456ef49751749