### PR TITLE
Add marker mode to pencil tool

### DIFF
--- a/editor/ui/canvas.py
+++ b/editor/ui/canvas.py
@@ -22,6 +22,8 @@ from editor.tools.eraser_tool import EraserTool
 from editor.tools.line_arrow_tool import LineTool, ArrowTool
 from editor.undo_commands import AddCommand, MoveCommand, ScaleCommand
 
+MARKER_ALPHA = 120
+
 
 class Canvas(QGraphicsView):
     """Drawing canvas holding the image and drawn items."""
@@ -61,9 +63,12 @@ class Canvas(QGraphicsView):
         """)
 
         self._tool = "select"
-        self._pen = QPen(QColor(ModernColors.PRIMARY), 3)
+        self._pen_mode = "pencil"
+        self._base_pen_color = QColor(ModernColors.PRIMARY)
+        self._pen = QPen(self._base_pen_color, 3)
         self._pen.setCapStyle(Qt.RoundCap)
         self._pen.setJoinStyle(Qt.RoundJoin)
+        self._apply_pen_mode()
         self.undo_stack = QUndoStack(self)
         self._move_snapshot: Dict[QGraphicsItem, QPointF] = {}
         self._text_manager: Optional[TextManager] = None
@@ -139,6 +144,23 @@ class Canvas(QGraphicsView):
         self._pen.setWidth(w)
 
     def set_pen_color(self, color: QColor):
+        self._base_pen_color = QColor(color)
+        self._apply_pen_mode()
+
+    def set_pen_mode(self, mode: str):
+        self._pen_mode = mode
+        self._apply_pen_mode()
+
+    @property
+    def pen_mode(self) -> str:
+        return self._pen_mode
+
+    def _apply_pen_mode(self):
+        color = QColor(self._base_pen_color)
+        if self._pen_mode == "marker":
+            color.setAlpha(MARKER_ALPHA)
+        else:
+            color.setAlpha(255)
         self._pen.setColor(color)
 
     def export_image(self) -> QImage:

--- a/editor/ui/icon_factory.py
+++ b/editor/ui/icon_factory.py
@@ -66,6 +66,19 @@ def make_icon_pencil() -> QIcon:
     return QIcon(pm)
 
 
+def make_icon_marker() -> QIcon:
+    pm = _base_pixmap()
+    p = QPainter(pm)
+    p.setRenderHint(QPainter.Antialiasing)
+    # draw a thicker translucent stroke to represent a marker
+    color = QColor(ModernColors.PRIMARY)
+    color.setAlpha(150)
+    p.setPen(QPen(color, 7, Qt.SolidLine, Qt.RoundCap))
+    p.drawLine(10, 30, 30, 10)
+    p.end()
+    return QIcon(pm)
+
+
 def make_icon_text() -> QIcon:
     pm = _base_pixmap()
     p = QPainter(pm)

--- a/editor/ui/toolbar_factory.py
+++ b/editor/ui/toolbar_factory.py
@@ -1,8 +1,8 @@
 from typing import Dict
 
 from PySide6.QtCore import Qt, QSize
-from PySide6.QtGui import QAction, QKeySequence, QColor
-from PySide6.QtWidgets import QToolBar, QToolButton
+from PySide6.QtGui import QAction, QKeySequence, QColor, QActionGroup
+from PySide6.QtWidgets import QToolBar, QToolButton, QMenu
 
 from .styles import ModernColors, tools_toolbar_style
 from .color_widgets import ColorButton
@@ -13,6 +13,7 @@ from .icon_factory import (
     make_icon_line,
     make_icon_arrow,
     make_icon_pencil,
+    make_icon_marker,
     make_icon_text,
     make_icon_blur,
     make_icon_eraser,
@@ -279,7 +280,31 @@ def create_tools_toolbar(window, canvas):
     add_tool("ellipse", make_icon_ellipse(), "Эллипс", "O")
     add_tool("line", make_icon_line(), "Линия", "L")
     add_tool("arrow", make_icon_arrow(), "Стрелка", "A")
-    add_tool("free", make_icon_pencil(), "Карандаш", "P")
+    free_btn = add_tool("free", make_icon_pencil(), "Карандаш", "P")
+
+    menu = QMenu(free_btn)
+    grp = QActionGroup(menu)
+    act_pencil = menu.addAction("Карандаш")
+    act_marker = menu.addAction("Маркер")
+    for act in (act_pencil, act_marker):
+        act.setCheckable(True)
+        grp.addAction(act)
+
+    def _set_mode(mode: str):
+        canvas.set_pen_mode(mode)
+        free_btn.setIcon(make_icon_marker() if mode == "marker" else make_icon_pencil())
+        act_pencil.setChecked(mode == "pencil")
+        act_marker.setChecked(mode == "marker")
+
+    act_pencil.triggered.connect(lambda: _set_mode("pencil"))
+    act_marker.triggered.connect(lambda: _set_mode("marker"))
+
+    act_pencil.setChecked(canvas.pen_mode == "pencil")
+    act_marker.setChecked(canvas.pen_mode == "marker")
+    free_btn.setMenu(menu)
+    free_btn.setPopupMode(QToolButton.MenuButtonPopup)
+    free_btn.setIcon(make_icon_marker() if canvas.pen_mode == "marker" else make_icon_pencil())
+
     add_tool("blur", make_icon_blur(), "Блюр", "B")
     add_tool("erase", make_icon_eraser(), "Ластик", "E")
     add_tool("text", make_icon_text(), "Текст", "T")


### PR DESCRIPTION
## Summary
- allow choosing between pencil and semi-transparent marker from the freehand tool
- track pen mode and adjust pen alpha for marker
- include marker icon and menu in tools toolbar

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2616246bc832c91007abc74e42e4a