### PR TITLE
Disable toolbar context menus and add right-click marker selection

### DIFF
--- a/editor/ui/canvas.py
+++ b/editor/ui/canvas.py
@@ -23,6 +23,8 @@ from editor.tools.line_arrow_tool import LineTool, ArrowTool
 from editor.undo_commands import AddCommand, MoveCommand, ScaleCommand
 
 MARKER_ALPHA = 120
+PENCIL_WIDTH = 3
+MARKER_WIDTH = 15
 
 
 class Canvas(QGraphicsView):
@@ -65,7 +67,7 @@ class Canvas(QGraphicsView):
         self._tool = "select"
         self._pen_mode = "pencil"
         self._base_pen_color = QColor(ModernColors.PRIMARY)
-        self._pen = QPen(self._base_pen_color, 3)
+        self._pen = QPen(self._base_pen_color, PENCIL_WIDTH)
         self._pen.setCapStyle(Qt.RoundCap)
         self._pen.setJoinStyle(Qt.RoundJoin)
         self._apply_pen_mode()
@@ -159,8 +161,10 @@ class Canvas(QGraphicsView):
         color = QColor(self._base_pen_color)
         if self._pen_mode == "marker":
             color.setAlpha(MARKER_ALPHA)
+            self._pen.setWidth(MARKER_WIDTH)
         else:
             color.setAlpha(255)
+            self._pen.setWidth(PENCIL_WIDTH)
         self._pen.setColor(color)
 
     def export_image(self) -> QImage:

--- a/editor/ui/toolbar_factory.py
+++ b/editor/ui/toolbar_factory.py
@@ -247,6 +247,7 @@ def create_tools_toolbar(window, canvas):
     tools_tb.setOrientation(Qt.Vertical)
     tools_tb.setMovable(False)
     tools_tb.setFloatable(False)
+    tools_tb.setContextMenuPolicy(Qt.PreventContextMenu)
 
     # Улучшенные настройки для отображения стрелок
     tools_tb.setToolButtonStyle(Qt.ToolButtonIconOnly)
@@ -301,8 +302,8 @@ def create_tools_toolbar(window, canvas):
 
     act_pencil.setChecked(canvas.pen_mode == "pencil")
     act_marker.setChecked(canvas.pen_mode == "marker")
-    free_btn.setMenu(menu)
-    free_btn.setPopupMode(QToolButton.MenuButtonPopup)
+    free_btn.setContextMenuPolicy(Qt.CustomContextMenu)
+    free_btn.customContextMenuRequested.connect(lambda pos: menu.exec(free_btn.mapToGlobal(pos)))
     free_btn.setIcon(make_icon_marker() if canvas.pen_mode == "marker" else make_icon_pencil())
 
     add_tool("blur", make_icon_blur(), "Блюр", "B")
@@ -321,6 +322,7 @@ def create_actions_toolbar(window, canvas):
     tb = QToolBar("Actions")
     tb.setMovable(False)
     tb.setFloatable(False)
+    tb.setContextMenuPolicy(Qt.PreventContextMenu)
 
     # Улучшенные настройки для отображения стрелок
     tb.setToolButtonStyle(Qt.ToolButtonTextOnly)


### PR DESCRIPTION
## Summary
- Block default context menus on tool and action toolbars
- Switch marker/pencil via right-click menu on the freehand tool
- Make marker stroke thicker than pencil but slightly smaller than eraser

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2631ef2e8832c940ae4be1979c88e