### PR TITLE
Improve marker drawing continuity and transparency

### DIFF
--- a/editor/ui/canvas.py
+++ b/editor/ui/canvas.py
@@ -22,7 +22,7 @@ from editor.tools.eraser_tool import EraserTool
 from editor.tools.line_arrow_tool import LineTool, ArrowTool
 from editor.undo_commands import AddCommand, MoveCommand, ScaleCommand
 
-MARKER_ALPHA = 120
+MARKER_ALPHA = 80
 PENCIL_WIDTH = 3
 MARKER_WIDTH = 15
 


### PR DESCRIPTION
## Summary
- Render marker and pencil strokes as continuous paths for smoother drawing
- Increase marker transparency

## Testing
- `python -m py_compile editor/tools/pencil_tool.py editor/ui/canvas.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a264cf0f9c832cb77cd47de3883485