### PR TITLE
Activate freehand tool when selecting marker

### DIFF
--- a/editor/ui/toolbar_factory.py
+++ b/editor/ui/toolbar_factory.py
@@ -292,6 +292,11 @@ def create_tools_toolbar(window, canvas):
         grp.addAction(act)
 
     def _set_mode(mode: str):
+        # Choosing a drawing mode from the context menu should also
+        # activate the freehand tool so the user can start drawing
+        # immediately with the selected instrument.
+        canvas.set_tool("free")
+        free_btn.setChecked(True)
         canvas.set_pen_mode(mode)
         free_btn.setIcon(make_icon_marker() if mode == "marker" else make_icon_pencil())
         act_pencil.setChecked(mode == "pencil")


### PR DESCRIPTION
## Summary
- make selecting Marker from context menu immediately switch to freehand tool

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a267ab9384832ca5c6d6ccf2debcfd