### PR TITLE
Combine shape tools and lighten selection color

### DIFF
--- a/editor/ui/styles.py
+++ b/editor/ui/styles.py
@@ -69,13 +69,13 @@ def main_window_style() -> str:
     }}
 
     QToolButton:checked {{
-        background: rgba(37, 99, 235, 0.2);
-        color: white;
-        border: 1px solid rgba(29, 78, 216, 0.4);
+        background: {ModernColors.PRIMARY_LIGHT};
+        color: {ModernColors.TEXT_PRIMARY};
+        border: 1px solid {ModernColors.PRIMARY_HOVER};
     }}
 
     QToolButton:checked:hover {{
-        background: rgba(29, 78, 216, 0.3);
+        background: {ModernColors.PRIMARY_LIGHT};
     }}
 
     QLabel {{
@@ -122,9 +122,9 @@ def tools_toolbar_style() -> str:
     }}
     QToolButton:checked {{
         background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-            stop:0 rgba(37, 99, 235, 0.2),
-            stop:1 rgba(29, 78, 216, 0.3));
-        border: 1px solid rgba(29, 78, 216, 0.4);
+            stop:0 {ModernColors.PRIMARY_LIGHT},
+            stop:1 {ModernColors.PRIMARY_LIGHT});
+        border: 1px solid {ModernColors.PRIMARY_HOVER};
         box-shadow: 0 2px 8px rgba(37, 99, 235, 0.3);
     }}
     QToolButton:hover {{
@@ -133,8 +133,8 @@ def tools_toolbar_style() -> str:
     }}
     QToolButton:checked:hover {{
         background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-            stop:0 rgba(29, 78, 216, 0.3),
-            stop:1 rgba(37, 99, 235, 0.2));
+            stop:0 {ModernColors.PRIMARY_LIGHT},
+            stop:1 {ModernColors.PRIMARY_LIGHT});
     }}
     QToolButton:pressed {{
         transform: scale(0.95);


### PR DESCRIPTION
## Summary
- Merge rectangle and ellipse drawing tools into a single button with a context menu to choose the shape
- Soften toolbar selection highlighting to a pale blue tone

## Testing
- `python -m py_compile editor/ui/toolbar_factory.py editor/ui/styles.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a26c89c908832c98205c88bae67dbb