### PR TITLE
Improve eraser continuity and add size popup

### DIFF
--- a/editor/ui/canvas.py
+++ b/editor/ui/canvas.py
@@ -224,6 +224,12 @@ class Canvas(QGraphicsView):
         super().keyPressEvent(event)
 
     def mousePressEvent(self, event):
+        if event.button() == Qt.RightButton and self._tool == "erase":
+            if self.active_tool and hasattr(self.active_tool, "show_size_popup"):
+                global_pos = self.viewport().mapToGlobal(event.position().toPoint())
+                self.active_tool.show_size_popup(global_pos)
+            event.accept()
+            return
         if event.button() == Qt.LeftButton:
             if self._tool == "select":
                 items = self.scene.selectedItems()


### PR DESCRIPTION
## Summary
- Smooth eraser behavior by interpolating strokes to avoid gaps
- Add minimal popup to adjust eraser size via right click

## Testing
- `python -m py_compile editor/tools/eraser_tool.py editor/ui/canvas.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba11db8438832cbabf6b04d08f18be