### PR TITLE
Fix eraser size popup initialization for PySide6

### DIFF
--- a/editor/tools/eraser_tool.py
+++ b/editor/tools/eraser_tool.py
@@ -198,7 +198,8 @@ class EraserTool(BaseTool):
 
 class _EraserSizePopup(QWidget):
     def __init__(self, tool: EraserTool):
-        super().__init__(flags=Qt.Popup)
+        super().__init__()
+        self.setWindowFlags(Qt.Popup)
         self.tool = tool
         self.slider = QSlider(Qt.Horizontal)
         self.slider.setRange(tool.min_size, tool.max_size)


### PR DESCRIPTION
## Summary
- ensure eraser size popup uses `setWindowFlags(Qt.Popup)` after QWidget init

## Testing
- `python -m py_compile editor/tools/eraser_tool.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba22ac2b18832c90ec352a873f003f