### PR TITLE
Improve text box resizing and clipboard capture

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -107,7 +107,9 @@ class SelectionOverlayBase(QWidget):
                 out = Image.new("RGBA", (w, h), (0, 0, 0, 0))
                 out.paste(crop, (0, 0), mask)
                 crop = out
-                self.captured.emit(ImageQt.ImageQt(crop))
+                qimg = ImageQt.ImageQt(crop).convertToFormat(QImage.Format_ARGB32)
+                QGuiApplication.clipboard().setImage(qimg)
+                self.captured.emit(qimg)
         self.releaseKeyboard()
         self.cancel_all.emit()
 


### PR DESCRIPTION
## Summary
- Allow text boxes to be resized from all four corners with directional cursors
- Automatically copy captured screenshots to the clipboard with preserved transparency

## Testing
- `python -m py_compile editor/text_tools.py gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba9c0c8dc0832cac1dbaac73ea969b