### PR TITLE
Fix text box resize offset

### DIFF
--- a/editor/text_tools.py
+++ b/editor/text_tools.py
@@ -32,7 +32,7 @@ class EditableTextItem(QGraphicsTextItem):
 
         # Параметры для изменения размера текстового блока
         self._resizing = False
-        self._resize_start_pos = QPointF()
+        self._resize_start_scene_pos = QPointF()
         self._resize_start_rect = QRectF()
         self._resize_handle = None
         self._resize_start_font_size = self._font.pointSizeF()
@@ -273,7 +273,7 @@ class EditableTextItem(QGraphicsTextItem):
                 if handle_rect.contains(event.pos()):
                     self._resizing = True
                     self._resize_handle = name
-                    self._resize_start_pos = event.pos()
+                    self._resize_start_scene_pos = event.scenePos()
                     self._resize_start_rect = rect
                     self._resize_start_font_size = self._font.pointSizeF()
                     event.accept()
@@ -310,7 +310,7 @@ class EditableTextItem(QGraphicsTextItem):
 
     def mouseMoveEvent(self, event):
         if self._resizing and self._resize_handle:
-            delta = event.pos() - self._resize_start_pos
+            delta = event.scenePos() - self._resize_start_scene_pos
             w0 = self._resize_start_rect.width()
             h0 = self._resize_start_rect.height()
 


### PR DESCRIPTION
## Summary
- keep text boxes anchored during top-right resizing

## Testing
- `python -m py_compile editor/text_tools.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bab3e42f80832c849b19d85468e3a2