### PR TITLE
feat: add layer ordering context menu

### DIFF
--- a/editor/text_tools.py
+++ b/editor/text_tools.py
@@ -330,13 +330,20 @@ class EditableTextItem(QGraphicsTextItem):
 
     def contextMenuEvent(self, event):
         menu = QMenu()
+        act_front = menu.addAction("На передний план")
+        act_back = menu.addAction("На задний план")
+        menu.addSeparator()
         act_delete = menu.addAction("Удалить")
         chosen = menu.exec(event.screenPos())
         event.accept()
-        if chosen == act_delete:
-            scene = self.scene()
+        scene = self.scene()
+        view = scene.views()[0] if scene and scene.views() else None
+        if chosen == act_front and view:
+            view.bring_to_front(self)
+        elif chosen == act_back and view:
+            view.send_to_back(self)
+        elif chosen == act_delete:
             if scene:
-                view = scene.views()[0] if scene.views() else None
                 undo_stack = getattr(view, "undo_stack", None)
                 if undo_stack:
                     undo_stack.push(RemoveCommand(scene, self))

--- a/editor/undo_commands.py
+++ b/editor/undo_commands.py
@@ -66,3 +66,20 @@ class ScaleCommand(QUndoCommand):
     def redo(self):
         for item, (old, new) in self.items_scale.items():
             item.setScale(new)
+
+
+class ZValueCommand(QUndoCommand):
+    """Command to change Z-order of items."""
+
+    def __init__(self, items_z):
+        # items_z: Dict[QGraphicsItem, Tuple[float, float]]
+        super().__init__("Порядок")
+        self.items_z = items_z
+
+    def undo(self):
+        for item, (old, new) in self.items_z.items():
+            item.setZValue(old)
+
+    def redo(self):
+        for item, (old, new) in self.items_z.items():
+            item.setZValue(new)


### PR DESCRIPTION
## Summary
- add ZValueCommand for undoable z-order changes
- add right-click actions to send items forward or back
- extend text item menu with layer controls

## Testing
- `python -m py_compile editor/undo_commands.py editor/ui/canvas.py editor/text_tools.py`


------
https://chatgpt.com/codex/tasks/task_e_68bace9cf2e8832c8d95bc20d7079ae3