### PR TITLE
Improve screenshot workflow and add help menu

### DIFF
--- a/editor/editor_window.py
+++ b/editor/editor_window.py
@@ -54,7 +54,29 @@ class EditorWindow(QMainWindow):
 
         QTimer.singleShot(0, lambda q=qimg: size_to_image(self, q))
 
-        self.statusBar().showMessage("Готово | Ctrl+N: новый скриншот | Ctrl+K: история | Ctrl+L: Live | Del: удалить | Ctrl +/-: масштаб", 5000)
+        self.statusBar().showMessage(
+            "Готово | Ctrl+N: новый скриншот | Ctrl+K: история | Ctrl+L: Live | Del: удалить | Ctrl +/-: масштаб",
+            5000,
+        )
+
+        # Меню справки с горячими клавишами
+        help_menu = self.menuBar().addMenu("Справка")
+        act_shortcuts = help_menu.addAction("Горячие клавиши")
+        act_shortcuts.triggered.connect(self.show_shortcuts)
+
+    def show_shortcuts(self):
+        text = (
+            "Ctrl+N — новый снимок\n"
+            "Ctrl+K — история\n"
+            "Ctrl+L — Live Text\n"
+            "Ctrl+C — копировать\n"
+            "Ctrl+S — сохранить\n"
+            "Ctrl+Z — отмена\n"
+            "Ctrl+Y — повтор\n"
+            "Delete — удалить\n"
+            "Ctrl+Plus/Minus — масштаб"
+        )
+        QMessageBox.information(self, "Горячие клавиши", text)
 
     # ---- actions ----
     def choose_color(self):
@@ -137,11 +159,10 @@ class EditorWindow(QMainWindow):
         pixmap = QPixmap(qimg.size())
         pixmap.fill(Qt.transparent)
         painter = QPainter(pixmap)
-        painter.setRenderHints(
-            QPainter.Antialiasing
-            | QPainter.HighQualityAntialiasing
-            | QPainter.SmoothPixmapTransform
-        )
+        hints = QPainter.Antialiasing | QPainter.SmoothPixmapTransform
+        if hasattr(QPainter, "HighQualityAntialiasing"):
+            hints |= QPainter.HighQualityAntialiasing
+        painter.setRenderHints(hints)
         path = QPainterPath()
         path.addRoundedRect(QRectF(0, 0, qimg.width(), qimg.height()), radius, radius)
         painter.setClipPath(path)

--- a/editor/ui/toolbar_factory.py
+++ b/editor/ui/toolbar_factory.py
@@ -4,6 +4,8 @@ from PySide6.QtCore import Qt, QSize
 from PySide6.QtGui import QAction, QKeySequence, QColor, QActionGroup
 from PySide6.QtWidgets import QToolBar, QToolButton, QMenu
 
+from logic import save_config
+
 from .styles import ModernColors, tools_toolbar_style
 from .color_widgets import ColorButton
 from .icon_factory import (
@@ -408,7 +410,7 @@ def create_actions_toolbar(window, canvas):
 
     actions: Dict[str, QAction] = {}
     actions['live'], _ = add_action("Live", window.toggle_live_text, sc="Ctrl+L", icon_text="🔍", show_text=False)
-    actions['new'], _ = add_action("Новый снимок", window.add_screenshot, sc="Ctrl+N", icon_text="📸", show_text=False)
+    actions['new'], new_btn = add_action("Новый снимок", window.add_screenshot, sc="Ctrl+N", icon_text="📸", show_text=False)
     actions['collage'], _ = add_action("История", window.open_collage, sc="Ctrl+K", icon_text="🖼", show_text=False)
     add_action("Копировать", window.copy_to_clipboard, sc="Ctrl+C", icon_text="📋", show_text=False)
     add_action("Сохранить", window.save_image, sc="Ctrl+S", icon_text="💾", show_text=False)
@@ -425,6 +427,21 @@ def create_actions_toolbar(window, canvas):
         btn.setText(text)
         btn.setToolButtonStyle(Qt.ToolButtonTextOnly)
         tb.addWidget(btn)
+
+    # Контекстное меню для выбора формы скриншота
+    def show_shape_menu(pos):
+        menu = QMenu(new_btn)
+        rect_act = menu.addAction("Прямоугольник")
+        circle_act = menu.addAction("Круг")
+        chosen = menu.exec(new_btn.mapToGlobal(pos))
+        if chosen == rect_act:
+            window.cfg["shape"] = "rect"
+        elif chosen == circle_act:
+            window.cfg["shape"] = "ellipse"
+        save_config(window.cfg)
+
+    new_btn.setContextMenuPolicy(Qt.CustomContextMenu)
+    new_btn.customContextMenuRequested.connect(show_shape_menu)
 
     # Применяем улучшенные стили
     tb.setStyleSheet(enhanced_actions_toolbar_style())


### PR DESCRIPTION
## Summary
- Fix rounded screenshot rendering to avoid missing `HighQualityAntialiasing`
- Allow choosing rectangle or circle capture via right-click on "New screenshot"
- Add help menu listing hotkeys and hide launcher after first capture

## Testing
- `python -m py_compile editor/editor_window.py editor/ui/toolbar_factory.py gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68baea9627dc832c8d9b219aa54df531