### PR TITLE
Bring new drawings to front and add canvas zoom slider

### DIFF
--- a/editor/tools/blur_tool.py
+++ b/editor/tools/blur_tool.py
@@ -64,6 +64,8 @@ class BlurTool(BaseTool):
                 item = self._create_blur_item(rect)
                 if item:
                     self.canvas.undo_stack.push(AddCommand(self.canvas.scene, item))
+                    # Ensure new blur items appear above existing elements
+                    self.canvas.bring_to_front(item)
 
     def _generate_blur_pixmap(self, rect: QRectF):
         img_rect = self.canvas.pixmap_item.boundingRect()

--- a/editor/tools/line_arrow_tool.py
+++ b/editor/tools/line_arrow_tool.py
@@ -23,6 +23,7 @@ class LineTool(BaseTool):
             self._tmp.setFlag(QGraphicsItem.ItemIsMovable, True)
             self._tmp.setFlag(QGraphicsItem.ItemIsSelectable, True)
             self.canvas.undo_stack.push(AddCommand(self.canvas.scene, self._tmp))
+            self.canvas.bring_to_front(self._tmp)
         else:
             self._tmp.setLine(QLineF(self._start, pos))
 
@@ -46,6 +47,7 @@ class ArrowTool(BaseTool):
         if self._tmp is None:
             self._tmp = self._create_arrow_group(self._start, pos)
             self._tmp.setFlag(QGraphicsItem.ItemIsSelectable, True)
+            self.canvas.bring_to_front(self._tmp)
         else:
             self.canvas.scene.removeItem(self._tmp)
             self._tmp = self._create_arrow_group(self._start, pos)
@@ -54,6 +56,7 @@ class ArrowTool(BaseTool):
     def release(self, pos: QPointF):  # noqa: D401
         if self._tmp is not None:
             self.canvas.undo_stack.push(AddCommand(self.canvas.scene, self._tmp))
+            self.canvas.bring_to_front(self._tmp)
             self._tmp = None
 
     def _create_arrow_group(self, start: QPointF, end: QPointF):

--- a/editor/tools/pencil_tool.py
+++ b/editor/tools/pencil_tool.py
@@ -34,5 +34,7 @@ class PencilTool(BaseTool):
                 self._path.lineTo(pos)
                 self._path_item.setPath(self._path)
             self.canvas.undo_stack.push(AddCommand(self.canvas.scene, self._path_item))
+            # Bring the new drawing to the front automatically
+            self.canvas.bring_to_front(self._path_item)
             self._path = None
             self._path_item = None

--- a/editor/tools/shape_tools.py
+++ b/editor/tools/shape_tools.py
@@ -32,6 +32,7 @@ class RectangleTool(_BaseShapeTool):
             self._tmp.setFlag(QGraphicsItem.ItemIsSelectable, True)
             self._tmp.setFlag(QGraphicsItem.ItemIsMovable, True)
             self.canvas.undo_stack.push(AddCommand(self.canvas.scene, self._tmp))
+            self.canvas.bring_to_front(self._tmp)
         else:
             self._tmp.setPath(path)
 
@@ -45,5 +46,6 @@ class EllipseTool(_BaseShapeTool):
             self._tmp.setFlag(QGraphicsItem.ItemIsSelectable, True)
             self._tmp.setFlag(QGraphicsItem.ItemIsMovable, True)
             self.canvas.undo_stack.push(AddCommand(self.canvas.scene, self._tmp))
+            self.canvas.bring_to_front(self._tmp)
         else:
             self._tmp.setRect(QRectF(self._start, pos).normalized())

--- a/editor/ui/canvas.py
+++ b/editor/ui/canvas.py
@@ -75,6 +75,7 @@ class Canvas(QGraphicsView):
         self.undo_stack = QUndoStack(self)
         self._move_snapshot: Dict[QGraphicsItem, QPointF] = {}
         self._text_manager: Optional[TextManager] = None
+        self._zoom = 1.0
 
         self.tools = {
             "select": SelectionTool(self),
@@ -167,6 +168,12 @@ class Canvas(QGraphicsView):
             color.setAlpha(255)
             self._pen.setWidth(PENCIL_WIDTH)
         self._pen.setColor(color)
+
+    def set_zoom(self, factor: float):
+        """Set the zoom level of the canvas."""
+        self._zoom = factor
+        self.resetTransform()
+        self.scale(factor, factor)
 
     def export_image(self) -> QImage:
         selected = [it for it in self.scene.selectedItems()]

--- a/editor/ui/toolbar_factory.py
+++ b/editor/ui/toolbar_factory.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 from PySide6.QtCore import Qt, QSize
 from PySide6.QtGui import QAction, QKeySequence, QColor, QActionGroup
-from PySide6.QtWidgets import QToolBar, QToolButton, QMenu
+from PySide6.QtWidgets import QToolBar, QToolButton, QMenu, QSlider, QLabel
 
 from logic import save_config
 
@@ -406,6 +406,18 @@ def create_actions_toolbar(window, canvas):
     color_btn.clicked.connect(window.choose_color)
     tb.addWidget(color_btn)
 
+    tb.addSeparator()
+
+    # Zoom slider for canvas scaling
+    zoom_slider = QSlider(Qt.Horizontal)
+    zoom_slider.setRange(10, 400)
+    zoom_slider.setValue(100)
+    zoom_slider.setFixedWidth(120)
+    zoom_slider.setToolTip("Масштаб")
+    zoom_label = QLabel("100%")
+    zoom_slider.valueChanged.connect(lambda v: (canvas.set_zoom(v / 100), zoom_label.setText(f"{v}%")))
+    tb.addWidget(zoom_slider)
+    tb.addWidget(zoom_label)
     tb.addSeparator()
 
     actions: Dict[str, QAction] = {}


### PR DESCRIPTION
## Summary
- Ensure blur, pencil, shape, line and arrow tools automatically bring created items to the foreground
- Introduce a canvas zoom slider in the actions toolbar for easier scaling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baed76f8a0832c9728a8d32374ce95