### PR TITLE
Fix crash in blur tool due to QRect toAlignedRect call

### DIFF
--- a/editor/tools/blur_tool.py
+++ b/editor/tools/blur_tool.py
@@ -79,7 +79,7 @@ class BlurTool(BaseTool):
 
         # expand source rect so blur has neighboring pixels to sample from
         expanded = rect.adjusted(-radius, -radius, radius, radius)
-        expanded = expanded.intersected(img_rect).toAlignedRect()
+        expanded = expanded.intersected(img_rect)
         ex, ey, ew, eh = expanded.x(), expanded.y(), expanded.width(), expanded.height()
 
         img = QImage(ew, eh, QImage.Format_RGBA8888)


### PR DESCRIPTION
## Summary
- Avoid calling `toAlignedRect()` on `QRect` when expanding the blur area to prevent AttributeError in PySide6

## Testing
- `python -m py_compile editor/tools/blur_tool.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bb0a460e50832ca485eb3514d1e443