### PR TITLE
Fix blur extending beyond image adds black outside bounds

### DIFF
--- a/editor/tools/blur_tool.py
+++ b/editor/tools/blur_tool.py
@@ -68,7 +68,7 @@ class BlurTool(BaseTool):
                     self.canvas.bring_to_front(item)
 
     def _generate_blur_pixmap(self, rect: QRectF):
-        img_rect = self.canvas.pixmap_item.boundingRect()
+        img_rect = self.canvas.pixmap_item.pixmap().rect()
         img_rect = self.canvas.pixmap_item.mapRectToScene(img_rect).toAlignedRect()
 
         rect = rect.intersected(img_rect).toAlignedRect()


### PR DESCRIPTION
## Summary
- prevent blur regions from covering outside the screenshot with black pixels

## Testing
- `python -m py_compile editor/tools/blur_tool.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb46f87aa4832c94a1642c400efeb8