### PR TITLE
Keep blur overlays above all layers

### DIFF
--- a/editor/tools/blur_tool.py
+++ b/editor/tools/blur_tool.py
@@ -53,9 +53,13 @@ class BlurTool(BaseTool):
             pix, pos = result
             if self._preview_item is None:
                 self._preview_item = self.canvas.scene.addPixmap(pix)
-                self._preview_item.setZValue(1)
             else:
                 self._preview_item.setPixmap(pix)
+            max_z = max(
+                (it.zValue() for it in self.canvas.scene.items() if it is not self._preview_item),
+                default=0,
+            )
+            self._preview_item.setZValue(max_z + 1)
             self._preview_item.setPos(pos)
 
     def release(self, pos: QPointF):


### PR DESCRIPTION
## Summary
- Ensure new and existing blur items always render above other graphics
- Adjust send_to_back/bring_to_front to maintain blur on top
- Keep blur preview above all items while drawing

## Testing
- `pytest`
- `python -m py_compile editor/ui/canvas.py editor/tools/blur_tool.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb6234e4d0832c98d41905fa7d538c