### PR TITLE
Prevent eraser from affecting screenshot layers

### DIFF
--- a/editor/editor_window.py
+++ b/editor/editor_window.py
@@ -178,6 +178,7 @@ class EditorWindow(QMainWindow):
         screenshot_item.setFlag(QGraphicsItem.ItemIsSelectable, True)
         screenshot_item.setFlag(QGraphicsItem.ItemIsFocusable, True)
         screenshot_item.setZValue(10)
+        screenshot_item.setData(0, "screenshot")
         self.canvas.scene.addItem(screenshot_item)
         self.canvas.undo_stack.push(AddCommand(self.canvas.scene, screenshot_item))
 

--- a/editor/tools/eraser_tool.py
+++ b/editor/tools/eraser_tool.py
@@ -111,7 +111,7 @@ class EraserTool(BaseTool):
 
         handled = False
         for item in self.canvas.scene.items(erase_rect):
-            if item is self.canvas.pixmap_item:
+            if isinstance(item, QGraphicsPixmapItem) and item.data(0) == "screenshot":
                 continue
             if isinstance(item, QGraphicsPixmapItem):
                 self._erase_pixmap_item(item, pos)

--- a/editor/ui/canvas.py
+++ b/editor/ui/canvas.py
@@ -43,6 +43,7 @@ class Canvas(QGraphicsView):
         self.pixmap_item.setFlag(QGraphicsItem.ItemIsSelectable, True)
         self.pixmap_item.setFlag(QGraphicsItem.ItemIsFocusable, True)
         self.pixmap_item.setZValue(0)
+        self.pixmap_item.setData(0, "screenshot")
         self.scene.addItem(self.pixmap_item)
 
         self.setDragMode(QGraphicsView.NoDrag)


### PR DESCRIPTION
## Summary
- Mark base and inserted screenshots with a `screenshot` tag
- Skip items tagged as screenshots in eraser to avoid removing images

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb671592e0832c9b247f109fee29d9