### PR TITLE
Add collage hotkey and improve selection controls

### DIFF
--- a/editor/editor_logic.py
+++ b/editor/editor_logic.py
@@ -14,7 +14,10 @@ class EditorLogic:
         return self.canvas.export_image()
 
     def copy_to_clipboard(self):
-        img = self.export_image()
+        if self.canvas.scene.selectedItems():
+            img = self.canvas.export_selection()
+        else:
+            img = self.export_image()
         qim = ImageQt.ImageQt(img)
         QApplication.clipboard().setImage(qim)
 

--- a/editor/ui/toolbar_factory.py
+++ b/editor/ui/toolbar_factory.py
@@ -422,7 +422,7 @@ def create_actions_toolbar(window, canvas):
 
     actions: Dict[str, QAction] = {}
     actions['live'], _ = add_action("Live", window.toggle_live_text, sc="Ctrl+L", icon_text="🔍", show_text=False)
-    actions['new'], new_btn = add_action("Новый снимок", window.add_screenshot, sc="Ctrl+N", icon_text="📸", show_text=False)
+    actions['new'], new_btn = add_action("Новый снимок", window.new_screenshot, sc="Ctrl+N", icon_text="📸", show_text=False)
     actions['collage'], _ = add_action("История", window.open_collage, sc="Ctrl+K", icon_text="🖼", show_text=False)
     add_action("Копировать", window.copy_to_clipboard, sc="Ctrl+C", icon_text="📋", show_text=False)
     add_action("Сохранить", window.save_image, sc="Ctrl+S", icon_text="💾", show_text=False)


### PR DESCRIPTION
## Summary
- Add Ctrl+Shift+N shortcut to append screenshots as a collage without clearing the canvas
- Copy and export only selected items and enable area selection
- Support deleting selected items via right-click menu

## Testing
- `python -m py_compile editor/editor_logic.py editor/editor_window.py editor/ui/canvas.py editor/ui/toolbar_factory.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c003acd070832cb19378a8bb670a5f