### PR TITLE
Add configurable screenshot hotkey

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -18,6 +18,7 @@ DEFAULT_CONFIG = {
     "tesseract_path": "",
     "pen_width": 3,
     "font_px": 18,
+    "capture_hotkey": "Ctrl+Alt+S",
 }
 
 def load_config() -> dict:


### PR DESCRIPTION
## Summary
- add `capture_hotkey` config option with default Ctrl+Alt+S
- add hotkey button allowing users to configure capture shortcut
- register global hotkey via QHotkey to trigger screenshot and blur screens

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c32fb86e5c832c895783ee07c6036c