### PR TITLE
Fix hotkey unregistration crash

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -509,11 +509,11 @@ class App(QObject):
     def _register_hotkey(self, seq: str):
         if self._hotkey_seq:
             try:
-                keybinder.unregister_hotkey(None, self._hotkey_seq)
-            except KeyError:
+                keybinder.unregister_hotkey(0, self._hotkey_seq)
+            except (KeyError, AttributeError):
                 pass
 
-        if keybinder.register_hotkey(None, seq, self.capture):
+        if keybinder.register_hotkey(0, seq, self.capture):
             self._hotkey_seq = seq
         else:
             self._hotkey_seq = None


### PR DESCRIPTION
## Summary
- avoid AttributeError when updating capture hotkey by using a zero window id for global hotkeys

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c34aada948832ca97ba4fe85facc02