### PR TITLE
Fix DIB conversion for PySide clipboard

### DIFF
--- a/editor/editor_logic.py
+++ b/editor/editor_logic.py
@@ -26,8 +26,13 @@ def _qimage_to_dib_bytes(qimg: QImage) -> bytes:
     img_size = bytes_per_line * height
 
     ptr = qimg.constBits()
-    ptr.setsize(img_size)
-    buffer = bytes(ptr)
+    if hasattr(ptr, "setsize"):
+        ptr.setsize(img_size)
+        buffer = bytes(ptr)
+    else:
+        buffer = ptr.tobytes()
+        if len(buffer) > img_size:
+            buffer = buffer[:img_size]
 
     header = struct.pack(
         "<IiiHHIIiiIIIII9iIIIIIII",


### PR DESCRIPTION
## Summary
- handle both sip-based and memoryview-based QImage buffers when building the BMP payload for the clipboard

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c970d71cb4832cb4e5208e56b8f76d