### PR TITLE
Fix clipboard transparency when copying screenshots

### DIFF
--- a/clipboard_utils.py
+++ b/clipboard_utils.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import struct
+from io import BytesIO
+from typing import Tuple
+
+from PIL import Image
+from PySide6.QtCore import QByteArray, QMimeData
+from PySide6.QtGui import QGuiApplication, QImage
+
+
+def qimage_to_dib_bytes(qimg: QImage) -> bytes:
+    """Convert a QImage to a top-down DIB byte stream preserving alpha."""
+
+    if qimg.isNull():
+        raise ValueError("QImage is null")
+
+    if qimg.format() != QImage.Format_ARGB32:
+        qimg = qimg.convertToFormat(QImage.Format_ARGB32)
+
+    width = qimg.width()
+    height = qimg.height()
+    if width == 0 or height == 0:
+        return b""
+
+    bytes_per_line = qimg.bytesPerLine()
+    img_size = bytes_per_line * height
+
+    ptr = qimg.constBits()
+    if hasattr(ptr, "setsize"):
+        ptr.setsize(img_size)
+        buffer = bytes(ptr)
+    else:
+        buffer = ptr.tobytes()
+        if len(buffer) > img_size:
+            buffer = buffer[:img_size]
+
+    header = b"".join(
+        (
+            struct.pack(
+                "<IiiHHIIiiII",
+                124,  # bV5Size
+                width,
+                -height,  # top-down DIB
+                1,  # planes
+                32,  # bit count
+                3,  # BI_BITFIELDS
+                img_size,
+                3780,  # ~96 DPI
+                3780,  # ~96 DPI
+                0,  # clr used
+                0,  # clr important
+            ),
+            struct.pack(
+                "<IIII",
+                0x00FF0000,  # red mask
+                0x0000FF00,  # green mask
+                0x000000FF,  # blue mask
+                0xFF000000,  # alpha mask
+            ),
+            struct.pack("<I", 0x57696E20),  # LCS_WINDOWS_COLOR_SPACE
+            struct.pack("<9i", *([0] * 9)),  # CIEXYZ endpoints
+            struct.pack(
+                "<IIIIIII",
+                0,  # gamma red
+                0,  # gamma green
+                0,  # gamma blue
+                4,  # LCS_GM_IMAGES
+                0,  # profile data
+                0,  # profile size
+                0,  # reserved
+            ),
+        )
+    )
+
+    return header + buffer
+
+
+def pil_to_qimage_with_png(img: Image.Image) -> Tuple[QImage, bytes]:
+    """Return a QImage and PNG byte representation for a PIL image."""
+
+    if img.mode != "RGBA":
+        img = img.convert("RGBA")
+
+    buffer = BytesIO()
+    img.save(buffer, format="PNG")
+    png_data = buffer.getvalue()
+
+    qimg = QImage.fromData(png_data, "PNG")
+    if qimg.format() != QImage.Format_ARGB32:
+        qimg = qimg.convertToFormat(QImage.Format_ARGB32)
+
+    return qimg, png_data
+
+
+def set_clipboard_from_qimage(qimg: QImage, png_data: bytes) -> None:
+    """Populate the clipboard with QImage, PNG and DIB representations."""
+
+    bmp_bytes = qimage_to_dib_bytes(qimg)
+
+    mime = QMimeData()
+    mime.setImageData(qimg)
+    mime.setData("image/png", QByteArray(png_data))
+    if bmp_bytes:
+        mime.setData("image/bmp", QByteArray(bmp_bytes))
+
+    QGuiApplication.clipboard().setMimeData(mime)
+
+
+def copy_pil_image_to_clipboard(img: Image.Image) -> QImage:
+    """Copy a PIL image to the clipboard preserving transparency."""
+
+    qimg, png_data = pil_to_qimage_with_png(img)
+    set_clipboard_from_qimage(qimg, png_data)
+    return qimg

--- a/editor/editor_logic.py
+++ b/editor/editor_logic.py
@@ -1,78 +1,10 @@
-from io import BytesIO
 from pathlib import Path
-import struct
 
 from PIL import Image
-from PySide6.QtCore import QMimeData, QByteArray
-from PySide6.QtGui import QImage
-from PySide6.QtWidgets import QApplication, QFileDialog
+from PySide6.QtWidgets import QFileDialog
 
+from clipboard_utils import copy_pil_image_to_clipboard
 from logic import HISTORY_DIR
-
-
-def _qimage_to_dib_bytes(qimg: QImage) -> bytes:
-    """Convert a QImage to a DIB (BITMAPV5HEADER) byte stream with alpha."""
-
-    if qimg.isNull():
-        raise ValueError("QImage is null")
-
-    qimg = qimg.convertToFormat(QImage.Format_ARGB32)
-    width = qimg.width()
-    height = qimg.height()
-    if width == 0 or height == 0:
-        return b""
-
-    bytes_per_line = qimg.bytesPerLine()
-    img_size = bytes_per_line * height
-
-    ptr = qimg.constBits()
-    if hasattr(ptr, "setsize"):
-        ptr.setsize(img_size)
-        buffer = bytes(ptr)
-    else:
-        buffer = ptr.tobytes()
-        if len(buffer) > img_size:
-            buffer = buffer[:img_size]
-
-    header = b"".join(
-        (
-            struct.pack(
-                "<IiiHHIIiiII",
-                124,  # bV5Size
-                width,
-                -height,  # top-down DIB
-                1,  # planes
-                32,  # bit count
-                3,  # BI_BITFIELDS
-                img_size,
-                3780,  # ~96 DPI
-                3780,  # ~96 DPI
-                0,  # clr used
-                0,  # clr important
-            ),
-            struct.pack(
-                "<IIII",
-                0x00FF0000,  # red mask
-                0x0000FF00,  # green mask
-                0x000000FF,  # blue mask
-                0xFF000000,  # alpha mask
-            ),
-            struct.pack("<I", 0x57696E20),  # LCS_WINDOWS_COLOR_SPACE
-            struct.pack("<9i", *([0] * 9)),  # CIEXYZ endpoints
-            struct.pack(
-                "<IIIIIII",
-                0,  # gamma red
-                0,  # gamma green
-                0,  # gamma blue
-                4,  # LCS_GM_IMAGES
-                0,  # profile data
-                0,  # profile size
-                0,  # reserved
-            ),
-        )
-    )
-
-    return header + buffer
 
 
 class EditorLogic:
@@ -88,31 +20,16 @@ class EditorLogic:
             img = self.canvas.export_selection()
         else:
             img = self.export_image()
-        if img.mode != "RGBA":
-            img = img.convert("RGBA")
-
-        buffer = BytesIO()
-        img.save(buffer, format="PNG")
-        data = buffer.getvalue()
-        qimg = QImage.fromData(data, "PNG")
-        qimg = qimg.convertToFormat(QImage.Format_ARGB32)
-
-        bmp_bytes = _qimage_to_dib_bytes(qimg)
-
-        mime = QMimeData()
-        mime.setImageData(qimg)
-        mime.setData("image/png", QByteArray(data))
-        if bmp_bytes:
-            mime.setData("image/bmp", QByteArray(bmp_bytes))
-
-        clipboard = QApplication.clipboard()
-        clipboard.setMimeData(mime)
+        copy_pil_image_to_clipboard(img)
 
     def save_image(self, parent):
         img = self.export_image()
         path, _ = QFileDialog.getSaveFileName(
-            parent, "Сохранить изображение", "",
-            "PNG (*.png);;JPEG (*.jpg);;Все файлы (*.*)")
+            parent,
+            "Сохранить изображение",
+            "",
+            "PNG (*.png);;JPEG (*.jpg);;Все файлы (*.*)",
+        )
         if not path:
             return None
         if path.lower().endswith((".jpg", ".jpeg")):
@@ -124,4 +41,6 @@ class EditorLogic:
         return self.live_manager.toggle()
 
     def collage_available(self):
-        return any(HISTORY_DIR.glob("*.png")) or any(HISTORY_DIR.glob("*.jpg")) or any(HISTORY_DIR.glob("*.jpeg"))
+        return any(HISTORY_DIR.glob("*.png")) or any(HISTORY_DIR.glob("*.jpg")) or any(
+            HISTORY_DIR.glob("*.jpeg")
+        )

--- a/gui.py
+++ b/gui.py
@@ -25,6 +25,7 @@ from PySide6.QtWidgets import (
 from pyqtkeybind import keybinder
 
 from logic import load_config, save_config, ScreenGrabber, qimage_to_pil, save_history
+from clipboard_utils import copy_pil_image_to_clipboard
 from editor.editor_window import EditorWindow
 from icons import make_icon_capture, make_icon_shape, make_icon_close
 
@@ -125,8 +126,7 @@ class SelectionOverlayBase(QWidget):
                     draw.rounded_rectangle((0, 0, w * scale, h * scale), radius=12 * scale, fill=255)
                 mask = mask.resize((w, h), Image.LANCZOS)
                 crop.putalpha(mask)
-                qimg = ImageQt.ImageQt(crop).convertToFormat(QImage.Format_ARGB32)
-                QGuiApplication.clipboard().setImage(qimg)
+                qimg = copy_pil_image_to_clipboard(crop)
                 self.captured.emit(qimg)
         self.releaseKeyboard()
         self.cancel_all.emit()


### PR DESCRIPTION
## Summary
- add a shared clipboard utility that exposes QImage, PNG and DIBv5 formats
- use the helper for screen captures and editor copies to keep transparent pixels in pastes

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68c9cd7be408832c8f1834e36bdf39f0