### PR TITLE
Copy OCR text selection and reuse editor window

### DIFF
--- a/editor/editor_logic.py
+++ b/editor/editor_logic.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from PIL import Image
+from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import QFileDialog
 
 from clipboard_utils import copy_pil_image_to_clipboard
@@ -16,11 +17,25 @@ class EditorLogic:
         return self.canvas.export_image()
 
     def copy_to_clipboard(self):
+        text = ""
+        if self.live_manager:
+            try:
+                text = (self.live_manager.selected_text() or "").strip()
+            except Exception:
+                text = ""
+
+        if text:
+            QGuiApplication.clipboard().setText(text)
+            return "text"
+
         if self.canvas.scene.selectedItems():
             img = self.canvas.export_selection()
-        else:
-            img = self.export_image()
+            copy_pil_image_to_clipboard(img)
+            return "selection"
+
+        img = self.export_image()
         copy_pil_image_to_clipboard(img)
+        return "image"
 
     def save_image(self, parent):
         img = self.export_image()

--- a/editor/editor_window.py
+++ b/editor/editor_window.py
@@ -96,8 +96,14 @@ class EditorWindow(QMainWindow):
                 self.text_manager.apply_color_to_selected(selected_items, focus_item)
 
     def copy_to_clipboard(self):
-        self.logic.copy_to_clipboard()
-        self.statusBar().showMessage("✅ Скопировано в буфер обмена", 2000)
+        result = self.logic.copy_to_clipboard()
+        if result == "text":
+            message = "✅ Текст скопирован в буфер обмена"
+        elif result == "selection":
+            message = "✅ Фрагмент скриншота скопирован"
+        else:
+            message = "✅ Скриншот скопирован"
+        self.statusBar().showMessage(message, 2000)
 
     def save_image(self):
         name = self.logic.save_image(self)
@@ -158,6 +164,18 @@ class EditorWindow(QMainWindow):
         self.activateWindow()
         QApplication.processEvents()
         QTimer.singleShot(0, lambda: (self.raise_(), self.activateWindow()))
+
+    def load_base_screenshot(self, qimg: QImage, message: str = "📸 Новый скриншот", duration: int = 2000):
+        try:
+            if getattr(self, "live_manager", None):
+                self.live_manager.disable()
+        except Exception:
+            pass
+        self.canvas.set_base_image(qimg)
+        self.canvas.setFocus(Qt.OtherFocusReason)
+        self._update_collage_enabled()
+        if message:
+            self.statusBar().showMessage(message, duration)
 
     def add_screenshot(self, collage: bool = False):
         try:
@@ -225,8 +243,7 @@ class EditorWindow(QMainWindow):
                 "📸 Новый скриншот добавлен (можно двигать и масштабировать)", 2500
             )
         else:
-            self.canvas.set_base_image(qimg)
-            self.statusBar().showMessage("📸 Новый скриншот", 2000)
+            self.load_base_screenshot(qimg)
         
     # ---- collage ----
     def open_collage(self):


### PR DESCRIPTION
## Summary
- copy OCR-recognized text to the clipboard when a Live Text selection is present instead of exporting the image
- add an editor helper to reload the base screenshot and reuse an existing editor window when the capture hotkey is pressed inside it
- track the focused editor before capture so the updated image is routed back to that window after grabbing

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ca53670cac832c9c3ed986703ed987