### PR TITLE
Close screenshot preview on outside click

### DIFF
--- a/collage.py
+++ b/collage.py
@@ -1,9 +1,10 @@
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 from pathlib import Path
 
-from PySide6.QtCore import Qt, QSize
+from PySide6.QtCore import Qt, QSize, QEvent
 from PySide6.QtGui import QIcon, QPixmap
 from PySide6.QtWidgets import (
+    QApplication,
     QDialog,
     QGridLayout,
     QHBoxLayout,
@@ -15,6 +16,56 @@ from PySide6.QtWidgets import (
 )
 
 from logic import HISTORY_DIR
+
+
+class PreviewDialog(QDialog):
+    """Dialog that closes automatically when clicking outside of it."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._event_filter_installed = False
+
+    def showEvent(self, event):
+        super().showEvent(event)
+        self._install_event_filter()
+
+    def hideEvent(self, event):
+        self._remove_event_filter()
+        super().hideEvent(event)
+
+    def closeEvent(self, event):
+        self._remove_event_filter()
+        super().closeEvent(event)
+
+    def eventFilter(self, watched, event):
+        if event.type() == QEvent.MouseButtonPress and self.isVisible():
+            if getattr(watched, "isWidgetType", lambda: False)():
+                if watched is self or self.isAncestorOf(watched):
+                    return False
+
+            global_pos = (
+                event.globalPosition().toPoint()
+                if hasattr(event, "globalPosition")
+                else event.globalPos()
+            )
+            if not self.rect().contains(self.mapFromGlobal(global_pos)):
+                self._remove_event_filter()
+                self.reject()
+                return False
+
+        return super().eventFilter(watched, event)
+
+    def _install_event_filter(self) -> None:
+        app = QApplication.instance()
+        if app and not self._event_filter_installed:
+            app.installEventFilter(self)
+            self._event_filter_installed = True
+
+    def _remove_event_filter(self) -> None:
+        app = QApplication.instance()
+        if app and self._event_filter_installed:
+            app.removeEventFilter(self)
+            self._event_filter_installed = False
 
 
 class CollageDialog(QDialog):
@@ -29,6 +80,7 @@ class CollageDialog(QDialog):
         layout.addLayout(self.grid)
 
         self._buttons: List[Tuple[QToolButton, Path]] = []
+        self._preview_dialog: Optional[PreviewDialog] = None
 
         paths = sorted(
             HISTORY_DIR.glob("shot_*.png"),
@@ -73,7 +125,10 @@ class CollageDialog(QDialog):
 
     def _preview_image(self, path: Path) -> None:
         """Open a simple dialog to preview the screenshot."""
-        dlg = QDialog(self)
+        if self._preview_dialog is not None:
+            self._preview_dialog.close()
+
+        dlg = PreviewDialog(self)
         dlg.setWindowTitle(path.name)
         vbox = QVBoxLayout(dlg)
         scroll = QScrollArea(dlg)
@@ -85,5 +140,10 @@ class CollageDialog(QDialog):
         scroll.setWidget(label)
         vbox.addWidget(scroll)
         dlg.resize(min(pix.width() + 20, 800), min(pix.height() + 20, 600))
-        dlg.exec()
+        dlg.finished.connect(self._on_preview_closed)
+        self._preview_dialog = dlg
+        dlg.show()
+
+    def _on_preview_closed(self, _result: int) -> None:
+        self._preview_dialog = None
 


### PR DESCRIPTION
## Summary
- add a custom preview dialog that closes itself when the user clicks outside its bounds
- keep the collage history preview non-modal and reuse a single instance while it is visible

## Testing
- python -m py_compile collage.py

------
https://chatgpt.com/codex/tasks/task_e_68ca8d1e9614832c9845db6ba26d5fca