### PR TITLE
Fix hotkey parsing with PySide6 key combinations

### DIFF
--- a/pyqtkeybind/win/keybindutil.py
+++ b/pyqtkeybind/win/keybindutil.py
@@ -12,6 +12,12 @@ from .keycodes import KeyTbl, ModsTbl
 def keys_from_string(keys):
     keysequence = QKeySequence(keys)
     ks = keysequence[0]
+    # PySide6 6.7+ returns ``QKeyCombination`` objects instead of the previous
+    # integer representation.  The downstream bitwise operations expect an
+    # ``int`` so convert the combination when necessary while keeping
+    # backwards compatibility with older versions that still return integers.
+    if hasattr(ks, "toCombined"):
+        ks = ks.toCombined()
 
     # Calculate the modifiers
     mods = 0


### PR DESCRIPTION
## Summary
- convert QKeyCombination instances from QKeySequence into integer values before bitwise operations
- keep backwards compatibility with older PySide6 releases that already returned ints

## Testing
- python -m compileall pyqtkeybind/win/keybindutil.py

------
https://chatgpt.com/codex/tasks/task_e_68cb3ac967b0832c9b2e7b7c73cbdf1f