### PR TITLE
Add Microsoft Teams sharing button

### DIFF
--- a/editor/ui/teams_dialog.py
+++ b/editor/ui/teams_dialog.py
@@ -1,0 +1,74 @@
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QLineEdit,
+    QLabel,
+    QMessageBox,
+    QVBoxLayout,
+)
+
+
+class TeamsSettingsDialog(QDialog):
+    """Dialog that lets the user configure Microsoft Teams integration."""
+
+    def __init__(self, parent, cfg: dict):
+        super().__init__(parent)
+        self.setWindowTitle("Настройки Microsoft Teams")
+        self.setModal(True)
+        self.setMinimumWidth(420)
+
+        layout = QVBoxLayout(self)
+
+        info = QLabel(
+            "Укажите отображаемое имя и адрес входящего вебхука Teams.\n"
+            "URL можно создать в канале Microsoft Teams через пункт"
+            " «Подключить вебхуки»."
+        )
+        info.setWordWrap(True)
+        layout.addWidget(info)
+
+        form = QFormLayout()
+        form.setLabelAlignment(Qt.AlignLeft)
+
+        self.name_edit = QLineEdit(cfg.get("teams_user_name", ""))
+        self.email_edit = QLineEdit(cfg.get("teams_user_email", ""))
+        self.webhook_edit = QLineEdit(cfg.get("teams_webhook_url", ""))
+        self.webhook_edit.setPlaceholderText("https://outlook.office.com/webhook/…")
+
+        form.addRow("Имя в Teams", self.name_edit)
+        form.addRow("Электронная почта", self.email_edit)
+        form.addRow("Webhook URL", self.webhook_edit)
+
+        layout.addLayout(form)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        buttons.button(QDialogButtonBox.Save).setText("Сохранить")
+        buttons.button(QDialogButtonBox.Cancel).setText("Отмена")
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def accept(self) -> None:
+        name = self.name_edit.text().strip()
+        webhook = self.webhook_edit.text().strip()
+
+        if not name:
+            QMessageBox.warning(self, "Microsoft Teams", "Укажите имя, отображаемое в Teams.")
+            self.name_edit.setFocus()
+            return
+
+        if not webhook:
+            QMessageBox.warning(self, "Microsoft Teams", "Укажите адрес входящего вебхука Teams.")
+            self.webhook_edit.setFocus()
+            return
+
+        super().accept()
+
+    def values(self) -> dict:
+        return {
+            "teams_user_name": self.name_edit.text().strip(),
+            "teams_user_email": self.email_edit.text().strip(),
+            "teams_webhook_url": self.webhook_edit.text().strip(),
+        }

--- a/editor/ui/toolbar_factory.py
+++ b/editor/ui/toolbar_factory.py
@@ -426,6 +426,18 @@ def create_actions_toolbar(window, canvas):
     actions['collage'], _ = add_action("История", window.open_collage, sc="Ctrl+K", icon_text="🖼", show_text=False)
     add_action("Копировать", window.copy_to_clipboard, sc="Ctrl+C", icon_text="📋", show_text=False)
     add_action("Сохранить", window.save_image, sc="Ctrl+S", icon_text="💾", show_text=False)
+    actions['teams'], teams_btn = add_action(
+        "Отправить в Teams",
+        window.send_to_teams,
+        sc="Ctrl+Shift+T",
+        icon_text="🟣",
+        show_text=False,
+    )
+    teams_btn.setPopupMode(QToolButton.MenuButtonPopup)
+    teams_menu = QMenu(teams_btn)
+    cfg_act = teams_menu.addAction("Настройки Teams…")
+    cfg_act.triggered.connect(window.open_teams_settings)
+    teams_btn.setMenu(teams_menu)
 
     undo_act = canvas.undo_stack.createUndoAction(window, "Отмена")
     undo_act.setShortcut(QKeySequence("Ctrl+Z"))

--- a/logic.py
+++ b/logic.py
@@ -20,6 +20,9 @@ DEFAULT_CONFIG = {
     "pen_width": 3,
     "font_px": 18,
     "capture_hotkey": "Ctrl+Alt+S",
+    "teams_webhook_url": "",
+    "teams_user_name": "",
+    "teams_user_email": "",
 }
 
 def load_config() -> dict:

--- a/teams_integration.py
+++ b/teams_integration.py
@@ -1,0 +1,94 @@
+"""Utilities for sending messages to Microsoft Teams."""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Optional
+from urllib import error, request
+
+
+class TeamsSendError(Exception):
+    """Raised when a message cannot be delivered to Microsoft Teams."""
+
+
+def _build_message_card(
+    user_name: str,
+    user_email: str,
+    message: str,
+    image_bytes: Optional[bytes],
+) -> dict:
+    """Construct the payload for an incoming webhook message card."""
+
+    identity = user_name.strip()
+    if user_email.strip():
+        identity = f"{identity} <{user_email.strip()}>"
+
+    body_text_parts = []
+    if message.strip():
+        body_text_parts.append(message.strip())
+    body_text_parts.append(f"Отправитель: {identity}")
+
+    card: dict = {
+        "@type": "MessageCard",
+        "@context": "http://schema.org/extensions",
+        "summary": f"Сообщение от {user_name}",
+        "themeColor": "4B53BC",
+        "title": f"SlipSnap — сообщение от {user_name}",
+        "text": "\n\n".join(body_text_parts),
+    }
+
+    if image_bytes:
+        image_data = base64.b64encode(image_bytes).decode("ascii")
+        card.setdefault("sections", []).append(
+            {
+                "activityTitle": "Вложение",
+                "activitySubtitle": "Скриншот из SlipSnap",
+                "images": [
+                    {
+                        "image": f"data:image/png;base64,{image_data}",
+                        "title": "Скриншот",
+                    }
+                ],
+            }
+        )
+
+    return card
+
+
+def send_message_to_teams(
+    webhook_url: str,
+    *,
+    user_name: str,
+    user_email: str = "",
+    message: str = "",
+    image_bytes: Optional[bytes] = None,
+    timeout: int = 10,
+) -> None:
+    """Send a message to Microsoft Teams via an incoming webhook."""
+
+    if not webhook_url:
+        raise TeamsSendError("Не указан адрес вебхука Microsoft Teams")
+
+    payload = _build_message_card(user_name, user_email, message, image_bytes)
+    data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    req = request.Request(
+        webhook_url,
+        data=data,
+        headers={"Content-Type": "application/json; charset=utf-8"},
+        method="POST",
+    )
+
+    try:
+        with request.urlopen(req, timeout=timeout) as resp:
+            status = getattr(resp, "status", resp.getcode())
+            if status >= 400:
+                raise TeamsSendError(f"Сервер вернул ошибку HTTP {status}")
+    except error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "ignore")
+        detail = detail.strip() or str(exc.reason)
+        raise TeamsSendError(f"HTTP {exc.code}: {detail}") from exc
+    except error.URLError as exc:
+        raise TeamsSendError(f"Не удалось подключиться к вебхуку: {exc.reason}") from exc
+    except ValueError as exc:
+        raise TeamsSendError(f"Некорректный адрес вебхука: {exc}") from exc


### PR DESCRIPTION
## Summary
- add a Microsoft Teams action button with shortcut and status messaging in the editor toolbar
- provide a configuration dialog to capture the current Teams identity and webhook URL
- implement a Teams webhook helper that posts the annotated screenshot alongside the authored message

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d2ce8ee0a8832ca76c7bcf3a07f145